### PR TITLE
RPC: make getdeploymentinfo report the block script flags being used

### DIFF
--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -5,6 +5,8 @@
 #include <deploymentinfo.h>
 
 #include <consensus/params.h>
+#include <script/interpreter.h>
+#include <tinyformat.h>
 
 const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_BITS_DEPLOYMENTS] = {
     {
@@ -31,4 +33,50 @@ std::string DeploymentName(Consensus::BuriedDeployment dep)
         return "taproot";
     } // no default case, so the compiler can warn about missing cases
     return "";
+}
+
+#define FLAG_NAME(flag) {std::string(#flag), (uint32_t)SCRIPT_VERIFY_##flag},
+const std::map<std::string, uint32_t> g_verify_flag_names{
+    FLAG_NAME(P2SH)
+    FLAG_NAME(STRICTENC)
+    FLAG_NAME(DERSIG)
+    FLAG_NAME(LOW_S)
+    FLAG_NAME(SIGPUSHONLY)
+    FLAG_NAME(MINIMALDATA)
+    FLAG_NAME(NULLDUMMY)
+    FLAG_NAME(DISCOURAGE_UPGRADABLE_NOPS)
+    FLAG_NAME(CLEANSTACK)
+    FLAG_NAME(MINIMALIF)
+    FLAG_NAME(NULLFAIL)
+    FLAG_NAME(CHECKLOCKTIMEVERIFY)
+    FLAG_NAME(CHECKSEQUENCEVERIFY)
+    FLAG_NAME(WITNESS)
+    FLAG_NAME(DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM)
+    FLAG_NAME(WITNESS_PUBKEYTYPE)
+    FLAG_NAME(CONST_SCRIPTCODE)
+    FLAG_NAME(TAPROOT)
+    FLAG_NAME(DISCOURAGE_UPGRADABLE_PUBKEYTYPE)
+    FLAG_NAME(DISCOURAGE_OP_SUCCESS)
+    FLAG_NAME(DISCOURAGE_UPGRADABLE_TAPROOT_VERSION)
+};
+#undef FLAG_NAME
+
+std::string FormatScriptFlags(uint32_t flags)
+{
+    if (flags == 0) return "";
+
+    std::string res = "";
+    uint32_t leftover = flags;
+    for (const auto& [name, flag] : g_verify_flag_names) {
+        if ((flags & flag) != 0) {
+            if (!res.empty()) res += ",";
+            res += name;
+            leftover &= ~flag;
+        }
+    }
+    if (leftover != 0) {
+        if (!res.empty()) res += ",";
+        res += strprintf("0x%08x", leftover);
+    }
+    return res;
 }

--- a/src/deploymentinfo.h
+++ b/src/deploymentinfo.h
@@ -7,6 +7,7 @@
 
 #include <consensus/params.h>
 
+#include <map>
 #include <string>
 
 /** What bits to set to signal activation */
@@ -41,5 +42,9 @@ inline int32_t CalculateAbandonVersion(int bip, int bip_version)
 {
     return (VERSIONBITS_TOP_ABANDON | (int32_t{bip} << 8) | bip_version);
 }
+
+extern const std::map<std::string, uint32_t> g_verify_flag_names;
+
+std::string FormatScriptFlags(uint32_t flags);
 
 #endif // BITCOIN_DEPLOYMENTINFO_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1672,7 +1672,8 @@ static RPCHelpMan getdeploymentinfo()
             RPCResult::Type::OBJ, "", "", {
                 {RPCResult::Type::STR, "hash", "requested block hash (or tip)"},
                 {RPCResult::Type::NUM, "height", "requested block height (or tip)"},
-                {RPCResult::Type::OBJ, "deployments", "", {
+                {RPCResult::Type::STR, "script_flags", "script verify flags for the block"},
+                {RPCResult::Type::OBJ_DYN, "deployments", "", {
                     {RPCResult::Type::OBJ, "xxxx", "name of the deployment", RPCHelpForDeployment}
                 }},
             }
@@ -1701,6 +1702,7 @@ static RPCHelpMan getdeploymentinfo()
             UniValue deploymentinfo(UniValue::VOBJ);
             deploymentinfo.pushKV("hash", blockindex->GetBlockHash().ToString());
             deploymentinfo.pushKV("height", blockindex->nHeight);
+            deploymentinfo.pushKV("script_flags", FormatScriptFlags(GetBlockScriptFlags(blockindex, consensusParams)));
             deploymentinfo.pushKV("deployments", DeploymentInfo(blockindex, consensusParams));
             return deploymentinfo;
         },

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -6,6 +6,7 @@
 #include <test/data/bip341_wallet_vectors.json.h>
 
 #include <core_io.h>
+#include <deploymentinfo.h>
 #include <fs.h>
 #include <key.h>
 #include <rpc/util.h>
@@ -39,7 +40,6 @@
 static const unsigned int gFlags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 
 unsigned int ParseScriptFlags(std::string strFlags);
-std::string FormatScriptFlags(unsigned int flags);
 
 UniValue read_json(const std::string& jsondata)
 {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -12,6 +12,7 @@
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
 #include <core_io.h>
+#include <deploymentinfo.h>
 #include <key.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
@@ -42,29 +43,7 @@ typedef std::vector<unsigned char> valtype;
 // In script_tests.cpp
 UniValue read_json(const std::string& jsondata);
 
-static std::map<std::string, unsigned int> mapFlagNames = {
-    {std::string("P2SH"), (unsigned int)SCRIPT_VERIFY_P2SH},
-    {std::string("STRICTENC"), (unsigned int)SCRIPT_VERIFY_STRICTENC},
-    {std::string("DERSIG"), (unsigned int)SCRIPT_VERIFY_DERSIG},
-    {std::string("LOW_S"), (unsigned int)SCRIPT_VERIFY_LOW_S},
-    {std::string("SIGPUSHONLY"), (unsigned int)SCRIPT_VERIFY_SIGPUSHONLY},
-    {std::string("MINIMALDATA"), (unsigned int)SCRIPT_VERIFY_MINIMALDATA},
-    {std::string("NULLDUMMY"), (unsigned int)SCRIPT_VERIFY_NULLDUMMY},
-    {std::string("DISCOURAGE_UPGRADABLE_NOPS"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS},
-    {std::string("CLEANSTACK"), (unsigned int)SCRIPT_VERIFY_CLEANSTACK},
-    {std::string("MINIMALIF"), (unsigned int)SCRIPT_VERIFY_MINIMALIF},
-    {std::string("NULLFAIL"), (unsigned int)SCRIPT_VERIFY_NULLFAIL},
-    {std::string("CHECKLOCKTIMEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY},
-    {std::string("CHECKSEQUENCEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKSEQUENCEVERIFY},
-    {std::string("WITNESS"), (unsigned int)SCRIPT_VERIFY_WITNESS},
-    {std::string("DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM},
-    {std::string("WITNESS_PUBKEYTYPE"), (unsigned int)SCRIPT_VERIFY_WITNESS_PUBKEYTYPE},
-    {std::string("CONST_SCRIPTCODE"), (unsigned int)SCRIPT_VERIFY_CONST_SCRIPTCODE},
-    {std::string("TAPROOT"), (unsigned int)SCRIPT_VERIFY_TAPROOT},
-    {std::string("DISCOURAGE_UPGRADABLE_PUBKEYTYPE"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE},
-    {std::string("DISCOURAGE_OP_SUCCESS"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS},
-    {std::string("DISCOURAGE_UPGRADABLE_TAPROOT_VERSION"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION},
-};
+static const std::map<std::string, unsigned int>& mapFlagNames = g_verify_flag_names;
 
 unsigned int ParseScriptFlags(std::string strFlags)
 {
@@ -75,9 +54,11 @@ unsigned int ParseScriptFlags(std::string strFlags)
 
     for (const std::string& word : words)
     {
-        if (!mapFlagNames.count(word))
+        if (!mapFlagNames.count(word)) {
             BOOST_ERROR("Bad test: unknown verification flag '" << word << "'");
-        flags |= mapFlagNames[word];
+            continue;
+        }
+        flags |= mapFlagNames.at(word);
     }
 
     return flags;
@@ -91,22 +72,6 @@ bool CheckMapFlagNames()
         standard_flags_missing &= ~(pair.second);
     }
     return standard_flags_missing == 0;
-}
-
-std::string FormatScriptFlags(unsigned int flags)
-{
-    if (flags == 0) {
-        return "";
-    }
-    std::string ret;
-    std::map<std::string, unsigned int>::const_iterator it = mapFlagNames.begin();
-    while (it != mapFlagNames.end()) {
-        if (flags & it->second) {
-            ret += it->first + ",";
-        }
-        it++;
-    }
-    return ret.substr(0, ret.size() - 1);
 }
 
 /*

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -282,9 +282,6 @@ bool CheckSequenceLocks(CBlockIndex* tip,
     return EvaluateSequenceLocks(index, lockPair);
 }
 
-// Returns the script flags which should be checked for a given block
-static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& chainparams);
-
 static void LimitMempoolSize(CTxMemPool& pool, CCoinsViewCache& coins_cache, size_t limit, std::chrono::seconds age)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main, pool.cs)
 {
@@ -1816,7 +1813,7 @@ void StopScriptCheckWorkerThreads()
     scriptcheckqueue.StopWorkerThreads();
 }
 
-static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& consensusparams)
+unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& consensusparams)
 {
     unsigned int flags = SCRIPT_VERIFY_NONE;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -1022,4 +1022,7 @@ bool LoadMempool(CTxMemPool& pool, CChainState& active_chainstate, FopenFn mocka
  */
 const AssumeutxoData* ExpectedAssumeutxo(const int height, const CChainParams& params);
 
+// Returns the script flags which should be checked for a given block
+unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& chainparams);
+
 #endif // BITCOIN_VALIDATION_H

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -186,6 +186,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(gdi_result, {
           "hash": blockhash,
           "height": height,
+          "script_flags": "CHECKLOCKTIMEVERIFY,CHECKSEQUENCEVERIFY,DERSIG,NULLDUMMY,P2SH,TAPROOT,WITNESS",
           "deployments": {
             'bip34': {'type': 'buried', 'active': True, 'height': 2},
             'bip66': {'type': 'buried', 'active': True, 'height': 3},


### PR DESCRIPTION
Since bitcoin inquisition is intended for evaluating proposed soft forks, making it easy to see that any `SCRIPT_VERIFY_*` flags corresponding to a soft fork are enabled seems helpful.