### PR TITLE
Add annex data carrier option behind -annexcarrier option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -567,6 +567,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-mempoolfullrbf", strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (default: %u)", DEFAULT_MEMPOOL_FULL_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-permitbaremultisig", strprintf("Relay non-P2SH multisig (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-annexcarrier", strprintf("Relay and mine transactions with annex data, up to %u bytes of payload (default: %u)", MAX_ANNEX_DATA, DEFAULT_ACCEPT_ANNEXDATA), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistforcerelay", strprintf("Add 'forcerelay' permission to whitelisted inbound peers with default permissions. This will relay transactions even if the transactions were already in the mempool. (default: %d)", DEFAULT_WHITELISTFORCERELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -50,6 +50,7 @@ struct MemPoolOptions {
      * If nullopt, any size is nonstandard.
      */
     std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
+    bool annex_datacarrier{DEFAULT_ACCEPT_ANNEXDATA};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
     bool require_standard{true};
     bool full_rbf{DEFAULT_MEMPOOL_FULL_RBF};

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -87,6 +87,8 @@ std::optional<bilingual_str> ApplyArgsManOptions(const ArgsManager& argsman, con
         mempool_opts.max_datacarrier_bytes = std::nullopt;
     }
 
+    mempool_opts.annex_datacarrier = argsman.GetBoolArg("-annexcarrier", DEFAULT_ACCEPT_ANNEXDATA);
+
     mempool_opts.require_standard = !argsman.GetBoolArg("-acceptnonstdtxn", !chainparams.RequireStandard());
     if (!chainparams.IsTestChain() && !mempool_opts.require_standard) {
         return strprintf(Untranslated("acceptnonstdtxn is not currently supported for %s chain"), chainparams.NetworkIDString());

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -132,9 +132,9 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 * 3600bytes witnessScript size, 80bytes per witness stack element, 100 witness stack elements
 * These limits are adequate for multisignatures up to n-of-100 using OP_CHECKSIG, OP_ADD, and OP_EQUAL.
 *
-* Also enforce a maximum stack item size limit and no annexes for tapscript spends.
+* Also enforce a maximum stack item size limit and limited annexes for tapscript spends.
 */
-bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, bool allow_annex_data);
 
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop);

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -17,6 +17,7 @@
 #include <variant>
 
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
+static const bool DEFAULT_ACCEPT_ANNEXDATA = true;
 
 class CKeyID;
 class CScript;
@@ -37,6 +38,17 @@ public:
  * +2 for the pushdata opcodes.
  */
 static const unsigned int MAX_OP_RETURN_RELAY = 83;
+
+/**
+ * Allows up to one annex data to be embedded in a transaction, counting towards the
+ * same data carrier limit as OP_RETURN values
+ */
+extern bool accept_annex_data;
+
+/**
+ * Static maximum of annex data per transaction
+ */
+static const unsigned int MAX_ANNEX_DATA = 126;
 
 /**
  * Mandatory script verification flags that all new blocks must comply with for

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -265,7 +265,7 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
                 (void)GetTransactionSigOpCost(transaction, coins_view_cache, flags);
             },
             [&] {
-                (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache);
+                (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache, /* allow_annex_data= */ true);
             });
     }
 }

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -98,7 +98,7 @@ FUZZ_TARGET_INIT(transaction, initialize_transaction)
     CCoinsView coins_view;
     const CCoinsViewCache coins_view_cache(&coins_view);
     (void)AreInputsStandard(tx, coins_view_cache);
-    (void)IsWitnessStandard(tx, coins_view_cache);
+    (void)IsWitnessStandard(tx, coins_view_cache, /* allow_annex_data= */true);
 
     UniValue u(UniValue::VOBJ);
     TxToUniv(tx, /*block_hash=*/uint256::ZERO, /*entry=*/u);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -433,6 +433,7 @@ CTxMemPool::CTxMemPool(const Options& opts)
       m_dust_relay_feerate{opts.dust_relay_feerate},
       m_permit_bare_multisig{opts.permit_bare_multisig},
       m_max_datacarrier_bytes{opts.max_datacarrier_bytes},
+      m_annex_datacarrier{opts.annex_datacarrier},
       m_require_standard{opts.require_standard},
       m_full_rbf{opts.full_rbf},
       m_limits{opts.limits}

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -573,6 +573,7 @@ public:
     const CFeeRate m_dust_relay_feerate;
     const bool m_permit_bare_multisig;
     const std::optional<unsigned> m_max_datacarrier_bytes;
+    const bool m_annex_datacarrier;
     const bool m_require_standard;
     const bool m_full_rbf;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -809,7 +809,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     // Check for non-standard witnesses.
-    if (tx.HasWitness() && m_pool.m_require_standard && !IsWitnessStandard(tx, m_view)) {
+    if (tx.HasWitness() && m_pool.m_require_standard && !IsWitnessStandard(tx, m_view, m_pool.m_annex_datacarrier)) {
         return state.Invalid(TxValidationResult::TX_WITNESS_MUTATED, "bad-witness-nonstandard");
     }
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -18,6 +18,7 @@ from test_framework.messages import (
     CTxIn,
     CTxInWitness,
     CTxOut,
+    MAX_ANNEX_DATA,
     SEQUENCE_FINAL,
 )
 from test_framework.script import (
@@ -680,9 +681,9 @@ def spenders_taproot_active():
 
     # == Tests for signature hashing ==
 
-    # Run all tests once with no annex, and once with a valid random annex.
-    for annex in [None, lambda _: bytes([ANNEX_TAG]) + random_bytes(random.randrange(0, 250))]:
-        # Non-empty annex is non-standard
+    # Run all tests once with no annex, and once with a valid yet non-standard random annex.
+    for annex in [None, lambda _: bytes([ANNEX_TAG, MAX_ANNEX_DATA + 1]) + random_bytes(random.randrange(0, 250))]:
+        # Non-empty annex is non-standard unless it's a specific format we avoid making in above lambda
         no_annex = annex is None
 
         # Sighash mutation tests (test all sighash combinations)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -71,6 +71,9 @@ DEFAULT_DESCENDANT_LIMIT = 25  # default max number of in-mempool descendants
 # Default setting for -datacarriersize. 80 bytes of data, +1 for OP_RETURN, +2 for the pushdata opcodes.
 MAX_OP_RETURN_RELAY = 83
 
+# Static max data for -annexcarrier
+MAX_ANNEX_DATA = 126
+
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 
 def sha256(s):


### PR DESCRIPTION
Allow 0 to 126 byte pushes in annex of the format:

`0x50 <1 byte data len> <len bytes>`

In the worst case this should add 129 WU of weight malleability to a transaction(including the witness stack element length byte).

This format is meant to be compatible with a full BIP proposal, and if it ends up being incompatible, removed, as this is policy only, on signet. https://github.com/bitcoin-inquisition/bitcoin/pull/9 Has a bit of work to go to get in prime time, so in the interim I'd like to base some speculative work on this specific carveout. 

I have special-purpose use for annex data that doesn't involve any softforks. My plan is to get this and https://github.com/bitcoin-inquisition/bitcoin/pull/23 into inquisition so people can start running eltoo CLN nodes on signet for experimentation/understanding. These same changes would support any number of APO-based channel architectures as well(Daric, AJ's two-stage with penalties, ???), so I think this is a solid step forward for experimentation without opening up the network to spam attacks.

See https://github.com/instagibbs/bolts/tree/eltoo_draft if you want way too much detail in how it's intended to be used.