### PR TITLE
Pseudo ephemeral anchors

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -568,6 +568,8 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-permitbaremultisig", strprintf("Relay non-P2SH multisig (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
     argsman.AddArg("-annexcarrier", strprintf("Relay and mine transactions with annex data, up to %u bytes of payload (default: %u)", MAX_ANNEX_DATA, DEFAULT_ACCEPT_ANNEXDATA), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ephemeralanchors", strprintf("Relay transactions with ephemeral anchors (default: %u)", DEFAULT_PERMIT_EA), ArgsManager::ALLOW_ANY,
+                   OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistforcerelay", strprintf("Add 'forcerelay' permission to whitelisted inbound peers with default permissions. This will relay transactions even if the transactions were already in the mempool. (default: %d)", DEFAULT_WHITELISTFORCERELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -570,6 +570,8 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-annexcarrier", strprintf("Relay and mine transactions with annex data, up to %u bytes of payload (default: %u)", MAX_ANNEX_DATA, DEFAULT_ACCEPT_ANNEXDATA), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-ephemeralanchors", strprintf("Relay transactions with ephemeral anchors (default: %u)", DEFAULT_PERMIT_EA), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-ephemeraldelta", strprintf("Mempool feerate modification to apply to otherwise 0-fee ephemeral anchor transactions (default: %s)", FormatMoney(DEFAULT_EPHEMERAL_DELTA)), ArgsManager::ALLOW_ANY,
+                   OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistforcerelay", strprintf("Add 'forcerelay' permission to whitelisted inbound peers with default permissions. This will relay transactions even if the transactions were already in the mempool. (default: %d)", DEFAULT_WHITELISTFORCERELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -194,6 +194,9 @@ public:
     //! Check if transaction has descendants in mempool.
     virtual bool hasDescendantsInMempool(const uint256& txid) = 0;
 
+    //! Check if ephemeral anchors are allowed.
+    virtual bool allowsEphemeralAnchors() = 0;
+
     //! Transaction is added to memory pool, if the transaction fee is below the
     //! amount specified by max_tx_fee, and broadcast to all peers if relay is set to true.
     //! Return false if the transaction could not be added due to the fee or for another reason.

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -52,6 +52,7 @@ struct MemPoolOptions {
     std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
     bool annex_datacarrier{DEFAULT_ACCEPT_ANNEXDATA};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
+    bool permit_ephemeral_anchors{DEFAULT_PERMIT_EA};
     bool require_standard{true};
     bool full_rbf{DEFAULT_MEMPOOL_FULL_RBF};
     MemPoolLimits limits{};

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -53,6 +53,7 @@ struct MemPoolOptions {
     bool annex_datacarrier{DEFAULT_ACCEPT_ANNEXDATA};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
     bool permit_ephemeral_anchors{DEFAULT_PERMIT_EA};
+    CFeeRate ephemeral_delta{DEFAULT_EPHEMERAL_DELTA};
     bool require_standard{true};
     bool full_rbf{DEFAULT_MEMPOOL_FULL_RBF};
     MemPoolLimits limits{};

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -624,6 +624,12 @@ public:
         auto it = m_node.mempool->GetIter(txid);
         return it && (*it)->GetCountWithDescendants() > 1;
     }
+    bool allowsEphemeralAnchors() override
+    {
+        if (!m_node.mempool) return false;
+        LOCK(m_node.mempool->cs);
+        return m_node.mempool->m_permit_anchors;
+    }
     bool broadcastTransaction(const CTransactionRef& tx,
         const CAmount& max_tx_fee,
         bool relay,

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -81,6 +81,8 @@ std::optional<bilingual_str> ApplyArgsManOptions(const ArgsManager& argsman, con
 
     mempool_opts.permit_bare_multisig = argsman.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
 
+    mempool_opts.permit_ephemeral_anchors = argsman.GetBoolArg("-ephemeralanchors", DEFAULT_PERMIT_EA);
+
     if (argsman.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER)) {
         mempool_opts.max_datacarrier_bytes = argsman.GetIntArg("-datacarriersize", MAX_OP_RETURN_RELAY);
     } else {

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -83,6 +83,14 @@ std::optional<bilingual_str> ApplyArgsManOptions(const ArgsManager& argsman, con
 
     mempool_opts.permit_ephemeral_anchors = argsman.GetBoolArg("-ephemeralanchors", DEFAULT_PERMIT_EA);
 
+    if (argsman.IsArgSet("-ephemeraldelta")) {
+        if (std::optional<CAmount> ephemeral_delta_feerate = ParseMoney(argsman.GetArg("-ephemeraldelta", ""))) {
+            mempool_opts.ephemeral_delta = CFeeRate{ephemeral_delta_feerate.value()};
+        } else {
+            return AmountErrMsg("ephemeraldelta", argsman.GetArg("-ephemeraldelta", ""));
+        }
+    }
+
     if (argsman.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER)) {
         mempool_opts.max_datacarrier_bytes = argsman.GetIntArg("-datacarriersize", MAX_OP_RETURN_RELAY);
     } else {

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -59,7 +59,7 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
         }
 
         // Check if it is final
-        if (!utxo.IsNull() && !PSBTInputSigned(input)) {
+        if (!PSBTInputSignedAndVerified(psbtx, i, &txdata)) {
             input_analysis.is_final = false;
 
             // Figure out what is missing

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -42,6 +42,10 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
     if (txout.scriptPubKey.IsUnspendable())
         return 0;
 
+    // Anchor outputs have no dust limit
+    if (txout.scriptPubKey.IsPayToAnchor())
+        return 0;
+
     size_t nSize = GetSerializeSize(txout);
     int witnessversion = 0;
     std::vector<unsigned char> witnessprogram;
@@ -142,11 +146,11 @@ bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_dat
         else if ((whichType == TxoutType::MULTISIG) && (!permit_bare_multisig)) {
             reason = "bare-multisig";
             return false;
-        } else if (whichType != TxoutType::ANCHOR && IsDust(txout, dust_relay_fee)) {
-            reason = "dust";
-            return false;
         } else if (whichType == TxoutType::ANCHOR && !permit_ephemeral_anchor) {
             reason = "ephemeral-anchor";
+            return false;
+        } else if (IsDust(txout, dust_relay_fee)) {
+            reason = "dust";
             return false;
         } else if (whichType == TxoutType::ANCHOR) {
             num_anchors++;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -91,7 +91,7 @@ bool IsStandard(const CScript& scriptPubKey, const std::optional<unsigned>& max_
     return true;
 }
 
-bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason)
+bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, bool permit_ephemeral_anchor, std::string& reason)
 {
     if (tx.nVersion > TX_MAX_STANDARD_VERSION || tx.nVersion < 1) {
         reason = "version";
@@ -143,6 +143,9 @@ bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_dat
             return false;
         } else if (whichType != TxoutType::ANCHOR && IsDust(txout, dust_relay_fee)) {
             reason = "dust";
+            return false;
+        } else if (whichType == TxoutType::ANCHOR && !permit_ephemeral_anchor) {
+            reason = "ephemeral-anchor";
             return false;
         }
     }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -321,6 +321,16 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
     return true;
 }
 
+size_t HasEphemeralAnchor(const CTransaction& tx)
+{
+    for (const CTxOut& txout : tx.vout) {
+        if (txout.scriptPubKey.IsPayToAnchor()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop)
 {
     return (std::max(nWeight, nSigOpCost * bytes_per_sigop) + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -141,7 +141,7 @@ bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_dat
         else if ((whichType == TxoutType::MULTISIG) && (!permit_bare_multisig)) {
             reason = "bare-multisig";
             return false;
-        } else if (IsDust(txout, dust_relay_fee)) {
+        } else if (whichType != TxoutType::ANCHOR && IsDust(txout, dust_relay_fee)) {
             reason = "dust";
             return false;
         }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -140,6 +140,11 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 */
 bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, bool allow_annex_data);
 
+/**
+* Check if given transaction has a IsPayToAnchor output.
+**/
+size_t HasEphemeralAnchor(const CTransaction& tx);
+
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop);
 int64_t GetVirtualTransactionSize(const CTransaction& tx, int64_t nSigOpCost, unsigned int bytes_per_sigop);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -37,6 +37,8 @@ static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
 /** Default for -permitbaremultisig */
 static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
+/** Default for -ephemeralanchors */
+static constexpr bool DEFAULT_PERMIT_EA{true};
 /** The maximum number of witness stack items in a standard P2WSH script */
 static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS{100};
 /** The maximum size in bytes of each witness stack item in a standard P2WSH script */
@@ -120,7 +122,7 @@ static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{2};
 * Check for standard transaction types
 * @return True if all outputs (scriptPubKeys) use only standard transaction forms
 */
-bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
+bool IsStandardTx(const CTransaction& tx, const std::optional<unsigned>& max_datacarrier_bytes, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, bool permit_ephemeral_anchors, std::string& reason);
 /**
 * Check for standard transaction types
 * @param[in] mapInputs       Map of previous transactions that have outputs we're spending

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -39,6 +39,8 @@ static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
 static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
 /** Default for -ephemeralanchors */
 static constexpr bool DEFAULT_PERMIT_EA{true};
+/** Default for -ephemeradelta */
+static constexpr unsigned int DEFAULT_EPHEMERAL_DELTA{1000};
 /** The maximum number of witness stack items in a standard P2WSH script */
 static constexpr unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS{100};
 /** The maximum size in bytes of each witness stack item in a standard P2WSH script */

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -1218,8 +1218,11 @@ std::string PSBTRoleName(PSBTRole role);
 /** Compute a PrecomputedTransactionData object from a psbt. */
 PrecomputedTransactionData PrecomputePSBTData(const PartiallySignedTransaction& psbt);
 
-/** Checks whether a PSBTInput is already signed. */
+/** Checks whether a PSBTInput is already signed by checking for non-null finalized fields. */
 bool PSBTInputSigned(const PSBTInput& input);
+
+/** Checks whether a PSBTInput is already signed by doing script verification using final fields. */
+bool PSBTInputSignedAndVerified(const PartiallySignedTransaction psbt, unsigned int input_index, const PrecomputedTransactionData* txdata);
 
 /** Signs a PSBTInput, verifying that all provided data matches what is being signed.
  *

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -154,6 +154,11 @@ static std::vector<RPCArg> CreateTxDoc()
                         {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A key-value pair. The key must be \"data\", the value is hex-encoded data"},
                     },
                 },
+                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                    {
+                        {"anchor", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "Creates an ephemeral anchor. A key-value pair. The key must be \"anchor\", the value is the amount in " + CURRENCY_UNIT},
+                    },
+                },
             },
         },
         {"locktime", RPCArg::Type::NUM, RPCArg::Default{0}, "Raw locktime. Non-0 value also locktime-activates inputs"},

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -422,6 +422,7 @@ static RPCHelpMan decodescript()
         case TxoutType::WITNESS_V1_TAPROOT:
         // don't wrap CTV because P2SH CTV is a hash cycle
         case TxoutType::TX_BARE_DEFAULT_CHECK_TEMPLATE_VERIFY_HASH:
+        case TxoutType::ANCHOR:
             // Should not be wrapped
             return false;
         } // no default case, so the compiler can warn about missing cases
@@ -466,6 +467,7 @@ static RPCHelpMan decodescript()
             case TxoutType::WITNESS_V1_TAPROOT:
             // don't wrap CTV because P2SH CTV is a hash cycle
             case TxoutType::TX_BARE_DEFAULT_CHECK_TEMPLATE_VERIFY_HASH:
+            case TxoutType::ANCHOR:
                 // Should not be wrapped
                 return false;
             } // no default case, so the compiler can warn about missing cases

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -198,6 +198,11 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
     return subscript.GetSigOpCount(true);
 }
 
+bool CScript::IsPayToAnchor() const
+{
+    return (this->size() == 1 && (*this)[0] == OP_TRUE);
+}
+
 bool CScript::IsPayToBareDefaultCheckTemplateVerifyHash() const
 {
     // Extra-fast test for pay-to-bare-default-check-template-verify-hash CScripts:
@@ -205,6 +210,7 @@ bool CScript::IsPayToBareDefaultCheckTemplateVerifyHash() const
             (*this)[0] == 0x20 &&
             (*this)[33] == OP_CHECKTEMPLATEVERIFY);
 }
+
 bool CScript::IsPayToScriptHash() const
 {
     // Extra-fast test for pay-to-script-hash CScripts:

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -532,6 +532,12 @@ public:
     unsigned int GetSigOpCount(const CScript& scriptSig) const;
 
     bool IsPayToBareDefaultCheckTemplateVerifyHash() const;
+
+    /*
+     * OP_TRUE
+     */
+    bool IsPayToAnchor() const;
+
     bool IsPayToScriptHash() const;
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -297,6 +297,7 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
     case TxoutType::NULL_DATA:
     case TxoutType::WITNESS_UNKNOWN:
     case TxoutType::TX_BARE_DEFAULT_CHECK_TEMPLATE_VERIFY_HASH:
+    case TxoutType::ANCHOR:
         return false;
     case TxoutType::PUBKEY:
         if (!CreateSig(creator, sigdata, provider, sig, CPubKey(vSolutions[0]), scriptPubKey, sigversion)) return false;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -52,6 +52,7 @@ std::string GetTxnOutputType(TxoutType t)
     case TxoutType::SCRIPTHASH: return "scripthash";
     case TxoutType::MULTISIG: return "multisig";
     case TxoutType::NULL_DATA: return "nulldata";
+    case TxoutType::ANCHOR: return "true";
     case TxoutType::WITNESS_V0_KEYHASH: return "witness_v0_keyhash";
     case TxoutType::WITNESS_V0_SCRIPTHASH: return "witness_v0_scripthash";
     case TxoutType::WITNESS_V1_TAPROOT: return "witness_v1_taproot";
@@ -179,6 +180,10 @@ TxoutType Solver(const CScript& scriptPubKey, std::vector<std::vector<unsigned c
         return TxoutType::SCRIPTHASH;
     }
 
+    if (scriptPubKey.IsPayToAnchor()) {
+        return TxoutType::ANCHOR;
+    }
+
     if (scriptPubKey.IsPayToBareDefaultCheckTemplateVerifyHash()) {
         return TxoutType::TX_BARE_DEFAULT_CHECK_TEMPLATE_VERIFY_HASH;
     }
@@ -291,6 +296,7 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
     case TxoutType::NULL_DATA:
     case TxoutType::TX_BARE_DEFAULT_CHECK_TEMPLATE_VERIFY_HASH:
     case TxoutType::NONSTANDARD:
+    case TxoutType::ANCHOR:
         return false;
     } // no default case, so the compiler can warn about missing cases
     assert(false);

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -63,6 +63,7 @@ static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;
 enum class TxoutType {
     NONSTANDARD,
     // 'standard' transaction types:
+    ANCHOR, //!< anyonecanspendable script
     PUBKEY,
     PUBKEYHASH,
     SCRIPTHASH,

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -79,11 +79,13 @@ FUZZ_TARGET_INIT(script, initialize_script)
                which_type == TxoutType::NONSTANDARD ||
                which_type == TxoutType::NULL_DATA ||
                which_type == TxoutType::TX_BARE_DEFAULT_CHECK_TEMPLATE_VERIFY_HASH ||
-               which_type == TxoutType::MULTISIG);
+               which_type == TxoutType::MULTISIG ||
+               which_type == TxoutType::ANCHOR);
     }
     if (which_type == TxoutType::NONSTANDARD ||
         which_type == TxoutType::NULL_DATA ||
-        which_type == TxoutType::MULTISIG) {
+        which_type == TxoutType::MULTISIG ||
+        which_type == TxoutType::ANCHOR) {
         assert(!extract_destination_ret);
     }
 
@@ -97,6 +99,7 @@ FUZZ_TARGET_INIT(script, initialize_script)
     (void)Solver(script, solutions);
 
     (void)script.HasValidOps();
+    (void)script.IsPayToAnchor();
     (void)script.IsPayToScriptHash();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -69,8 +69,8 @@ FUZZ_TARGET_INIT(transaction, initialize_transaction)
 
     const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
     std::string reason;
-    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
-    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
+    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ true, dust_relay_fee, /* permit_ephemeral_anchors= */ true, reason);
+    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, std::nullopt, /* permit_bare_multisig= */ false, dust_relay_fee, /* permit_ephemeral_anchors= */ true, reason);
     if (is_standard_without_permit_bare_multisig) {
         assert(is_standard_with_permit_bare_multisig);
     }

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -20,7 +20,7 @@
 // Helpers:
 static bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {
-    return IsStandardTx(tx, std::nullopt, DEFAULT_PERMIT_BAREMULTISIG, CFeeRate{DUST_RELAY_TX_FEE}, reason);
+    return IsStandardTx(tx, std::nullopt, DEFAULT_PERMIT_BAREMULTISIG, CFeeRate{DUST_RELAY_TX_FEE}, DEFAULT_PERMIT_EA, reason);
 }
 
 static std::vector<unsigned char> Serialize(const CScript& s)

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -128,6 +128,12 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     BOOST_CHECK(solutions[0] == std::vector<unsigned char>{16});
     BOOST_CHECK(solutions[1] == ToByteVector(uint256::ONE));
 
+    // TxoutType::ANCHOR
+    s.clear();
+    s << OP_1;
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::ANCHOR);
+    BOOST_CHECK_EQUAL(solutions.size(), 0);
+
     // TxoutType::NONSTANDARD
     s.clear();
     s << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
@@ -187,6 +193,16 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
     // TxoutType::WITNESS_UNKNOWN with incorrect program size
     s.clear();
     s << OP_0 << std::vector<unsigned char>(19, 0x01);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::NONSTANDARD);
+
+    // TxoutType::ANCHOR with extra push
+    s.clear();
+    s << OP_1 << OP_1;
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::NONSTANDARD);
+
+    // TxoutType::ANCHOR but wrong truth-y opcode
+    s.clear();
+    s << OP_2;
     BOOST_CHECK_EQUAL(Solver(s, solutions), TxoutType::NONSTANDARD);
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -926,12 +926,12 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
         CheckIsNotStandard(t, "dust");
     }
 
-    // Check anchor outputs (no dust allowed still)
+    // Check anchor outputs allow dust
     t.vout[0].scriptPubKey = CScript() << OP_1;
-    t.vout[0].nValue = 500;
-    CheckIsStandard(t);
     t.vout[0].nValue = 0;
-    CheckIsNotStandard(t, "dust");
+    CheckIsStandard(t);
+    t.vout[0].nValue = 1; // Not just 0
+    CheckIsStandard(t);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -43,6 +43,7 @@ UniValue read_json(const std::string& jsondata);
 
 static CFeeRate g_dust{DUST_RELAY_TX_FEE};
 static bool g_bare_multi{DEFAULT_PERMIT_BAREMULTISIG};
+static bool g_permit_anchor{DEFAULT_PERMIT_EA};
 
 static const std::map<std::string, unsigned int>& mapFlagNames = g_verify_flag_names;
 
@@ -732,12 +733,12 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     constexpr auto CheckIsStandard = [](const auto& t) {
         std::string reason;
-        BOOST_CHECK(IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi, g_dust, reason));
+        BOOST_CHECK(IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi, g_dust, g_permit_anchor, reason));
         BOOST_CHECK(reason.empty());
     };
     constexpr auto CheckIsNotStandard = [](const auto& t, const std::string& reason_in) {
         std::string reason;
-        BOOST_CHECK(!IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi, g_dust, reason));
+        BOOST_CHECK(!IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi, g_dust, g_permit_anchor, reason));
         BOOST_CHECK_EQUAL(reason_in, reason);
     };
 
@@ -932,6 +933,12 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsStandard(t);
     t.vout[0].nValue = 1; // Not just 0
     CheckIsStandard(t);
+
+    // Turn off ephemeral anchors
+    g_permit_anchor = false;
+    CheckIsNotStandard(t, "ephemeral-anchor");
+    t.vout[0].nValue = MAX_MONEY;
+    CheckIsNotStandard(t, "ephemeral-anchor");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -781,7 +781,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsStandard(t);
     g_dust = CFeeRate{DUST_RELAY_TX_FEE};
 
-    t.vout[0].scriptPubKey = CScript() << OP_1;
+    t.vout[0].scriptPubKey = CScript() << OP_2;
     CheckIsNotStandard(t, "scriptpubkey");
 
     // MAX_OP_RETURN_RELAY-byte TxoutType::NULL_DATA (standard)
@@ -925,6 +925,13 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
         t.vout[0].nValue = 239;
         CheckIsNotStandard(t, "dust");
     }
+
+    // Check anchor outputs (no dust allowed still)
+    t.vout[0].scriptPubKey = CScript() << OP_1;
+    t.vout[0].nValue = 500;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 0;
+    CheckIsNotStandard(t, "dust");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -433,6 +433,7 @@ CTxMemPool::CTxMemPool(const Options& opts)
       m_dust_relay_feerate{opts.dust_relay_feerate},
       m_permit_bare_multisig{opts.permit_bare_multisig},
       m_permit_anchors{opts.permit_ephemeral_anchors},
+      m_ephemeral_delta{opts.ephemeral_delta},
       m_max_datacarrier_bytes{opts.max_datacarrier_bytes},
       m_annex_datacarrier{opts.annex_datacarrier},
       m_require_standard{opts.require_standard},
@@ -461,14 +462,13 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
 /* Inquisition cheat to get around lack of package relay. Will only work
  * with default minrelayfee, with non-full mempools.
  */
-static const CFeeRate EPHEMERAL_DELTA{1000};
 void CTxMemPool::ApplyEphemeralDelta(const CTxMemPoolEntry& entry, CAmount& delta) const
 {
     if (delta != 0) return; // don't apply if a delta has been already applied
     if (entry.GetFee() > 0) return; // only adjust for 0 fee
     for (const auto& out : entry.GetTx().vout) {
         if (out.scriptPubKey.IsPayToAnchor()) {
-            delta = EPHEMERAL_DELTA.GetFee(entry.GetTxSize());
+            delta = m_ephemeral_delta.GetFee(entry.GetTxSize());
             return;
         }
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -432,6 +432,7 @@ CTxMemPool::CTxMemPool(const Options& opts)
       m_min_relay_feerate{opts.min_relay_feerate},
       m_dust_relay_feerate{opts.dust_relay_feerate},
       m_permit_bare_multisig{opts.permit_bare_multisig},
+      m_permit_anchors{opts.permit_ephemeral_anchors},
       m_max_datacarrier_bytes{opts.max_datacarrier_bytes},
       m_annex_datacarrier{opts.annex_datacarrier},
       m_require_standard{opts.require_standard},

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -572,6 +572,7 @@ public:
     const CFeeRate m_min_relay_feerate;
     const CFeeRate m_dust_relay_feerate;
     const bool m_permit_bare_multisig;
+    const bool m_permit_anchors;
     const std::optional<unsigned> m_max_datacarrier_bytes;
     const bool m_annex_datacarrier;
     const bool m_require_standard;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -635,6 +635,7 @@ public:
     /** Affect CreateNewBlock prioritisation of transactions */
     void PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta);
     void ApplyDelta(const uint256& hash, CAmount &nFeeDelta) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void ApplyEphemeralDelta(const CTxMemPoolEntry& entry, CAmount& delta) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void ClearPrioritisation(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Get the transaction in the pool that spends the same prevout */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -573,6 +573,7 @@ public:
     const CFeeRate m_dust_relay_feerate;
     const bool m_permit_bare_multisig;
     const bool m_permit_anchors;
+    const CFeeRate m_ephemeral_delta;
     const std::optional<unsigned> m_max_datacarrier_bytes;
     const bool m_annex_datacarrier;
     const bool m_require_standard;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -696,7 +696,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     std::string reason;
-    if (m_pool.m_require_standard && !IsStandardTx(tx, m_pool.m_max_datacarrier_bytes, m_pool.m_permit_bare_multisig, m_pool.m_dust_relay_feerate, reason)) {
+    if (m_pool.m_require_standard && !IsStandardTx(tx, m_pool.m_max_datacarrier_bytes, m_pool.m_permit_bare_multisig, m_pool.m_dust_relay_feerate, m_pool.m_permit_anchors, reason)) {
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, reason);
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -834,6 +834,9 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             fSpendsCoinbase, nSigOpsCost, lp));
     ws.m_vsize = entry->GetTxSize();
 
+    // Remove after package relay deployed: Apply ephemeral anchor delta now that we have entry initialized
+    m_pool.ApplyEphemeralDelta(*entry, ws.m_modified_fees);
+
     if (nSigOpsCost > MAX_STANDARD_TX_SIGOPS_COST)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-too-many-sigops",
                 strprintf("%d", nSigOpsCost));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -804,6 +804,11 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return false; // state filled in by CheckTxInputs
     }
 
+    // We check for 0-base-fee transaction here now that we have access to ws.m_base_fees.
+    if (HasEphemeralAnchor(tx) && ws.m_base_fees != 0) {
+        return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "invalid-ephemeral-fee");
+    }
+
     if (m_pool.m_require_standard && !AreInputsStandard(tx, m_view)) {
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs");
     }

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -911,6 +911,7 @@ static std::string RecurseImportData(const CScript& script, ImportData& import_d
     case TxoutType::NONSTANDARD:
     case TxoutType::WITNESS_UNKNOWN:
     case TxoutType::WITNESS_V1_TAPROOT:
+    case TxoutType::ANCHOR:
         return "unrecognized script";
     case TxoutType::TX_BARE_DEFAULT_CHECK_TEMPLATE_VERIFY_HASH:
         return "bare default CheckTemplateVerify hash";

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1585,6 +1585,11 @@ RPCHelpMan walletcreatefundedpsbt()
                                     {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A key-value pair. The key must be \"data\", the value is hex-encoded data"},
                                 },
                             },
+                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                                {
+                                    {"anchor", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "Creates an ephemeral anchor. A key-value pair. The key must be \"anchor\", the value is the amount in " + CURRENCY_UNIT},
+                                },
+                            },
                         },
                     },
                     {"locktime", RPCArg::Type::NUM, RPCArg::Default{0}, "Raw locktime. Non-0 value also locktime-activates inputs"},

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -104,6 +104,7 @@ IsMineResult IsMineInner(const LegacyScriptPubKeyMan& keystore, const CScript& s
     case TxoutType::NULL_DATA:
     case TxoutType::WITNESS_UNKNOWN:
     case TxoutType::WITNESS_V1_TAPROOT:
+    case TxoutType::ANCHOR:
         break;
     case TxoutType::PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -889,7 +889,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
             coin_selection_params.tx_noinputs_size += ::GetSerializeSize(txout, PROTOCOL_VERSION);
         }
 
-        if (!recipient.scriptPubKey.IsPayToAnchor() && IsDust(txout, wallet.chain().relayDustFee())) {
+        if (IsDust(txout, wallet.chain().relayDustFee())) {
             return util::Error{_("Transaction amount too small")};
         }
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -899,6 +899,12 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     const CAmount not_input_fees = coin_selection_params.m_effective_feerate.GetFee(coin_selection_params.tx_noinputs_size);
     CAmount selection_target = recipients_sum + not_input_fees;
 
+    // This can only happen if feerate is 0, and requested destinations are value of 0 (e.g. OP_RETURN)
+    // and no pre-selected inputs. This will result in 0-input transaction, which is consensus-invalid anyways
+    if (selection_target == 0 && !coin_control.HasSelected()) {
+        return util::Error{_("Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input")};
+    }
+
     // Get available coins
     auto available_coins = AvailableCoins(wallet,
                                               &coin_control,

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -889,9 +889,14 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
             coin_selection_params.tx_noinputs_size += ::GetSerializeSize(txout, PROTOCOL_VERSION);
         }
 
-        if (IsDust(txout, wallet.chain().relayDustFee())) {
+        if (!recipient.scriptPubKey.IsPayToAnchor() && IsDust(txout, wallet.chain().relayDustFee())) {
             return util::Error{_("Transaction amount too small")};
         }
+
+        if (recipient.scriptPubKey.IsPayToAnchor() && !wallet.chain().allowsEphemeralAnchors()) {
+            return util::Error{_("Anchor outputs are not allowed for relay: check -ephemeralanchors option")};
+        }
+
         txNew.vout.push_back(txout);
     }
 

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -101,7 +101,7 @@ class BIP65Test(BitcoinTestFramework):
 
     def run_test(self):
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
-        wallet = MiniWallet(self.nodes[0], mode=MiniWalletMode.RAW_OP_TRUE)
+        wallet = MiniWallet(self.nodes[0], mode=MiniWalletMode.RAW_OP_2)
 
         self.test_cltv_info(is_active=False)
 

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -29,7 +29,7 @@ from test_framework.messages import (
 from test_framework.script import (
     CScript,
     OP_0,
-    OP_1,
+    OP_2,
     OP_DROP,
     OP_TRUE,
 )
@@ -448,18 +448,18 @@ class SegWitTest(BitcoinTestFramework):
                     # Witness output types with uncompressed keys are never seen
                     unseen_anytime.extend([p2wpkh, p2sh_p2wpkh, p2wsh_p2pk, p2wsh_p2pkh, p2sh_p2wsh_p2pk, p2sh_p2wsh_p2pkh])
 
-            op1 = CScript([OP_1])
+            op2 = CScript([OP_2])
             op0 = CScript([OP_0])
             # 2N7MGY19ti4KDMSzRfPAssP6Pxyuxoi6jLe is the P2SH(P2PKH) version of mjoE3sSrb8ByYEvgnC3Aox86u1CHnfJA4V
             unsolvable_address_key = bytes.fromhex("02341AEC7587A51CDE5279E0630A531AEA2615A9F80B17E8D9376327BAEAA59E3D")
             unsolvablep2pkh = key_to_p2pkh_script(unsolvable_address_key)
             unsolvablep2wshp2pkh = script_to_p2wsh_script(unsolvablep2pkh)
             p2shop0 = script_to_p2sh_script(op0)
-            p2wshop1 = script_to_p2wsh_script(op1)
+            p2wshop2 = script_to_p2wsh_script(op2)
             unsolvable_after_importaddress.append(unsolvablep2pkh)
             unsolvable_after_importaddress.append(unsolvablep2wshp2pkh)
-            unsolvable_after_importaddress.append(op1)  # OP_1 will be imported as script
-            unsolvable_after_importaddress.append(p2wshop1)
+            unsolvable_after_importaddress.append(op2)  # OP_1 will be imported as script
+            unsolvable_after_importaddress.append(p2wshop2)
             unseen_anytime.append(op0)  # OP_0 will be imported as P2SH address with no script provided
             unsolvable_after_importaddress.append(p2shop0)
 
@@ -488,8 +488,8 @@ class SegWitTest(BitcoinTestFramework):
 
             importlist.append(unsolvablep2pkh.hex())
             importlist.append(unsolvablep2wshp2pkh.hex())
-            importlist.append(op1.hex())
-            importlist.append(p2wshop1.hex())
+            importlist.append(op2.hex())
+            importlist.append(p2wshop2.hex())
 
             for i in importlist:
                 # import all generated addresses. The wallet already has the private keys for some of these, so catch JSON RPC

--- a/test/functional/mempool_ephemeral_anchor.py
+++ b/test/functional/mempool_ephemeral_anchor.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import copy
+from decimal import Decimal
+
+from test_framework.messages import (
+    COIN,
+    CTxInWitness,
+    CTxOut,
+    MAX_BIP125_RBF_SEQUENCE,
+)
+from test_framework.script import (
+    CScript,
+    OP_TRUE,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    DEFAULT_FEE,
+    MiniWallet,
+)
+
+class EphemeralAnchorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def assert_mempool_contents(self, expected=None, unexpected=None):
+        """Assert that all transactions in expected are in the mempool,
+        and all transactions in unexpected are not in the mempool.
+        """
+        if not expected:
+            expected = []
+        if not unexpected:
+            unexpected = []
+        assert set(unexpected).isdisjoint(expected)
+        mempool = self.nodes[0].getrawmempool(verbose=False)
+        for tx in expected:
+            assert tx.rehash() in mempool
+        for tx in unexpected:
+            assert tx.rehash() not in mempool
+
+    def insert_additional_outputs(self, parent_result, additional_outputs):
+        # Modify transaction as needed to add ephemeral anchor
+        parent_tx = parent_result["tx"]
+        additional_sum = 0
+        for additional_output in additional_outputs:
+            parent_tx.vout.append(additional_output)
+            additional_sum += additional_output.nValue
+
+        # Steal value from destination and recompute fields
+        parent_tx.vout[0].nValue -= additional_sum
+        parent_result["txid"] = parent_tx.rehash()
+        parent_result["wtxid"] = parent_tx.getwtxid()
+        parent_result["hex"] = parent_tx.serialize().hex()
+        parent_result["new_utxo"] = {**parent_result["new_utxo"],  "txid": parent_result["txid"], "value": Decimal(parent_tx.vout[0].nValue)/COIN}
+
+
+    def spend_ephemeral_anchor_witness(self, child_result, child_inputs):
+        child_tx = child_result["tx"]
+        child_tx.wit.vtxinwit = [copy.deepcopy(child_tx.wit.vtxinwit[0]) if "anchor" not in x else CTxInWitness() for x in child_inputs]
+        child_result["hex"] = child_tx.serialize().hex()
+
+
+    def create_simple_package(self, parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, spend_anchor=1, additional_outputs=None):
+        """Create a 1 parent 1 child package using the coin passed in as the parent's input. The
+        parent has 1 output, used to fund 1 child transaction.
+        All transactions signal BIP125 replaceability, but nSequence changes based on self.ctr. This
+        prevents identical txids between packages when the parents spend the same coin and have the
+        same fee (i.e. 0sat).
+
+        returns tuple (hex serialized txns, CTransaction objects)
+        """
+
+        if additional_outputs is None:
+            additional_outputs=[CTxOut(0, CScript([OP_TRUE]))]
+
+        child_inputs = []
+        self.ctr += 1
+        # Use fee_rate=0 because create_self_transfer will use the default fee_rate value otherwise.
+        # Passing in fee>0 overrides fee_rate, so this still works for non-zero parent_fee.
+        parent_result = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=parent_fee,
+            utxo_to_spend=parent_coin,
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        self.insert_additional_outputs(parent_result, additional_outputs)
+
+        # Add inputs to child, depending on spend arg
+        child_inputs.append(parent_result["new_utxo"])
+        if spend_anchor:
+            for vout, output in enumerate(additional_outputs):
+                child_inputs.append({**parent_result["new_utxo"], 'vout': 1+vout, 'value': Decimal(output.nValue)/COIN, 'anchor': True})
+
+
+        child_result = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=child_inputs,
+            num_outputs=1,
+            fee_per_output=int(child_fee * COIN),
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+        )
+
+        if spend_anchor:
+            self.spend_ephemeral_anchor_witness(child_result, child_inputs)
+
+        package_hex = [parent_result["hex"], child_result["hex"]]
+        package_txns = [parent_result["tx"], child_result["tx"]]
+        return package_hex, package_txns
+
+    def run_test(self):
+        # Counter used to count the number of times we constructed packages. Since we're constructing parent transactions with the same
+        # coins (to create conflicts), and giving them the same fee (i.e. 0, since their respective children are paying), we might
+        # accidentally just create the exact same transaction again. To prevent this, set nSequences to MAX_BIP125_RBF_SEQUENCE - self.ctr.
+        self.ctr = 0
+
+        self.log.info("Generate blocks to create UTXOs")
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.generate(self.wallet, 160)
+        self.coins = self.wallet.get_utxos(mark_as_spent=False)
+        # Mature coinbase transactions
+        self.generate(self.wallet, 100)
+        self.address = self.wallet.get_address()
+
+        self.test_fee_having_parent()
+        self.test_multianchor()
+        self.test_nonzero_anchor()
+        self.test_prioritise_parent()
+
+    def test_fee_having_parent(self):
+        self.log.info("Test that a transaction with ephemeral anchor may not have base fee")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=1, child_fee=DEFAULT_FEE)
+        assert_raises_rpc_error(-26, "invalid-ephemeral-fee", node.submitpackage, package_hex0)
+        assert_equal(node.getrawmempool(), [])
+
+        # But works with no parent fee
+        package_hex1, package_txns1 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=[])
+
+        self.generate(node, 1)
+
+    def test_multianchor(self):
+        self.log.info("Test that a transaction with multiple ephemeral anchors is nonstandard")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, additional_outputs=[CTxOut(0, CScript([OP_TRUE]))] * 2)
+        assert_raises_rpc_error(-26, "too-many-ephemeral-anchors", node.submitpackage, package_hex0)
+        assert_equal(node.getrawmempool(), [])
+
+        self.generate(node, 1)
+
+    def test_nonzero_anchor(self):
+        def inner_test_anchor_value(output_value):
+            node = self.nodes[0]
+            # Reuse the same coins so that the transactions conflict with one another.
+            parent_coin = self.coins[-1]
+            del self.coins[-1]
+
+            package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, additional_outputs=[CTxOut(output_value, CScript([OP_TRUE]))])
+            node.submitpackage(package_hex0)
+            self.assert_mempool_contents(expected=package_txns0, unexpected=[])
+
+            self.generate(node, 1)
+
+        self.log.info("Test that a transaction with ephemeral anchor may have any otherwise legal satoshi value")
+        for i in range(5):
+            inner_test_anchor_value(int(i*COIN/4))
+
+    def test_prioritise_parent(self):
+        self.log.info("Test that prioritizing a parent transaction with ephemeral anchor doesn't cause mempool rejection due to non-0 parent fee")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins[-1]
+        del self.coins[-1]
+
+        # De-prioritising to 0-fee doesn't matter; it's just the base fee that matters
+        package_hex0, package_txns0 = self.create_simple_package(parent_coin=parent_coin, parent_fee=1, child_fee=DEFAULT_FEE)
+        parent_txid = node.decoderawtransaction(package_hex0[0])['txid']
+        node.prioritisetransaction(txid=parent_txid, dummy=0, fee_delta=COIN)
+        assert_raises_rpc_error(-26, "invalid-ephemeral-fee", node.submitpackage, package_hex0)
+        assert_equal(node.getrawmempool(), [])
+
+        # Also doesn't make it invalid if applied to the parent
+        package_hex1, package_txns1 = self.create_simple_package(parent_coin=parent_coin, parent_fee=0, child_fee=DEFAULT_FEE)
+        parent_txid = node.decoderawtransaction(package_hex1[0])['txid']
+        node.prioritisetransaction(txid=parent_txid, dummy=0, fee_delta=COIN)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=[])
+
+        self.generate(node, 1)
+
+
+if __name__ == "__main__":
+    EphemeralAnchorTest().main()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -252,7 +252,7 @@ class SegWitTest(BitcoinTestFramework):
 
         assert self.test_node.nServices & NODE_WITNESS != 0
 
-        # Keep a place to store utxo's that can be used in later tests
+        # Keep a place to store bare, non-standard utxo's that can be used in later tests
         self.utxo = []
 
         self.log.info("Starting tests before segwit activation")
@@ -330,7 +330,7 @@ class SegWitTest(BitcoinTestFramework):
 
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE])))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_2])))
         tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)])]
 
@@ -470,7 +470,7 @@ class SegWitTest(BitcoinTestFramework):
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b'')]
         tx.vout = [CTxOut(value, script_pubkey), CTxOut(value, p2sh_script_pubkey)]
-        tx.vout.append(CTxOut(value, CScript([OP_TRUE])))
+        tx.vout.append(CTxOut(value, CScript([OP_2])))
         tx.rehash()
         txid = tx.sha256
 
@@ -486,14 +486,14 @@ class SegWitTest(BitcoinTestFramework):
         # Now try to spend the outputs. This should fail since SCRIPT_VERIFY_WITNESS is always enabled.
         p2wsh_tx = CTransaction()
         p2wsh_tx.vin = [CTxIn(COutPoint(txid, 0), b'')]
-        p2wsh_tx.vout = [CTxOut(value, CScript([OP_TRUE]))]
+        p2wsh_tx.vout = [CTxOut(value, CScript([OP_2]))]
         p2wsh_tx.wit.vtxinwit.append(CTxInWitness())
         p2wsh_tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
         p2wsh_tx.rehash()
 
         p2sh_p2wsh_tx = CTransaction()
         p2sh_p2wsh_tx.vin = [CTxIn(COutPoint(txid, 1), CScript([script_pubkey]))]
-        p2sh_p2wsh_tx.vout = [CTxOut(value, CScript([OP_TRUE]))]
+        p2sh_p2wsh_tx.vout = [CTxOut(value, CScript([OP_2]))]
         p2sh_p2wsh_tx.wit.vtxinwit.append(CTxInWitness())
         p2sh_p2wsh_tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
         p2sh_p2wsh_tx.rehash()
@@ -695,7 +695,7 @@ class SegWitTest(BitcoinTestFramework):
         # Now test attempts to spend the output.
         spend_tx = CTransaction()
         spend_tx.vin.append(CTxIn(COutPoint(tx.sha256, 0), script_sig))
-        spend_tx.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        spend_tx.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_2])))
         spend_tx.rehash()
 
         # This transaction should not be accepted into the mempool pre- or
@@ -898,7 +898,7 @@ class SegWitTest(BitcoinTestFramework):
         child_tx = CTransaction()
         for i in range(NUM_OUTPUTS):
             child_tx.vin.append(CTxIn(COutPoint(parent_tx.sha256, i), b""))
-        child_tx.vout = [CTxOut(value - 100000, CScript([OP_TRUE]))]
+        child_tx.vout = [CTxOut(value - 100000, CScript([OP_2]))]
         for _ in range(NUM_OUTPUTS):
             child_tx.wit.vtxinwit.append(CTxInWitness())
             child_tx.wit.vtxinwit[-1].scriptWitness.stack = [b'a' * 195] * (2 * NUM_DROPS) + [witness_script]
@@ -987,7 +987,7 @@ class SegWitTest(BitcoinTestFramework):
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue - 2000, script_pubkey))
-        tx.vout.append(CTxOut(1000, CScript([OP_TRUE])))  # non-witness output
+        tx.vout.append(CTxOut(1000, CScript([OP_2])))  # non-witness output
         tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([])]
         tx.rehash()
@@ -1011,7 +1011,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))  # witness output
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 1), b""))  # non-witness
-        tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_2])))
         tx2.wit.vtxinwit.extend([CTxInWitness(), CTxInWitness()])
         tx2.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)]), CScript([CScriptNum(1)]), witness_script]
         tx2.wit.vtxinwit[1].scriptWitness.stack = [CScript([OP_TRUE])]
@@ -1065,7 +1065,7 @@ class SegWitTest(BitcoinTestFramework):
 
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_2])))
         tx2.wit.vtxinwit.append(CTxInWitness())
         # First try a 521-byte stack element
         tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a' * (MAX_SCRIPT_ELEMENT_SIZE + 1), witness_script]
@@ -1106,7 +1106,7 @@ class SegWitTest(BitcoinTestFramework):
 
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_2])))
         tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a'] * 44 + [long_witness_script]
         tx2.rehash()
@@ -1177,7 +1177,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2 = BrokenCTransaction()
         for i in range(10):
             tx2.vin.append(CTxIn(COutPoint(tx.sha256, i), b""))
-        tx2.vout.append(CTxOut(value - 3000, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(value - 3000, CScript([OP_2])))
 
         # First try using a too long vtxinwit
         for i in range(11):
@@ -1323,7 +1323,7 @@ class SegWitTest(BitcoinTestFramework):
             tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
             split_value = (self.utxo[0].nValue - 4000) // NUM_SEGWIT_VERSIONS
             for _ in range(NUM_SEGWIT_VERSIONS):
-                tx.vout.append(CTxOut(split_value, CScript([OP_TRUE])))
+                tx.vout.append(CTxOut(split_value, CScript([2])))
             tx.rehash()
             block = self.build_next_block()
             self.update_witness_block_with_transactions(block, [tx])
@@ -1348,6 +1348,7 @@ class SegWitTest(BitcoinTestFramework):
             tx.vin = [CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b"")]
             tx.vout = [CTxOut(self.utxo[0].nValue - 1000, script_pubkey)]
             tx.rehash()
+            # This will fail since all utxos currently in self.utxo are non-standard bare scripts
             test_transaction_acceptance(self.nodes[1], self.std_node, tx, with_witness=True, accepted=False)
             test_transaction_acceptance(self.nodes[0], self.test_node, tx, with_witness=True, accepted=True)
             self.utxo.pop(0)
@@ -1526,7 +1527,7 @@ class SegWitTest(BitcoinTestFramework):
         # transactions.
         tx5 = CTransaction()
         tx5.vin.append(CTxIn(COutPoint(tx4.sha256, 0), b""))
-        tx5.vout.append(CTxOut(tx4.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        tx5.vout.append(CTxOut(tx4.vout[0].nValue - 1000, CScript([OP_2])))
         (sig_hash, err) = LegacySignatureHash(script_pubkey, tx5, 0, SIGHASH_ALL)
         signature = key.sign_ecdsa(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
         tx5.vin[0].scriptSig = CScript([signature, pubkey])
@@ -1677,7 +1678,7 @@ class SegWitTest(BitcoinTestFramework):
         sign_p2pk_witness_input(witness_script, tx, 0, SIGHASH_ALL, temp_utxos[0].nValue, key)
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_2])))
 
         script = keyhash_to_p2pkh_script(pubkeyhash)
         sig_hash = SegwitV0SignatureHash(script, tx2, 0, SIGHASH_ALL, tx.vout[0].nValue)
@@ -1709,7 +1710,7 @@ class SegWitTest(BitcoinTestFramework):
         tx = CTransaction()
         index = 0
         # Just spend to our usual anyone-can-spend output
-        tx.vout = [CTxOut(output_value, CScript([OP_TRUE]))] * 2
+        tx.vout = [CTxOut(output_value, CScript([OP_2]))] * 2
         for i in temp_utxos:
             # Use SIGHASH_ALL|SIGHASH_ANYONECANPAY so we can build up
             # the signatures as we go.
@@ -1926,7 +1927,7 @@ class SegWitTest(BitcoinTestFramework):
             tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_script]
             total_value += tx.vout[i].nValue
         tx2.wit.vtxinwit[-1].scriptWitness.stack = [witness_script_toomany]
-        tx2.vout.append(CTxOut(total_value, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(total_value, CScript([OP_2])))
         tx2.rehash()
 
         block_2 = self.build_next_block()

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -884,6 +884,11 @@ class PSBTTest(BitcoinTestFramework):
 
         anchor_tx = self.nodes[0].finalizepsbt(self.nodes[0].walletprocesspsbt(psbt=funded_anchor["psbt"])["psbt"])["hex"]
 
+        # Modified fees equal 1 sat/vbyte
+        anchor_txid = self.nodes[0].sendrawtransaction(anchor_tx)
+        anchor_entry = self.nodes[0].getmempoolentry(anchor_txid)
+        assert_equal(Decimal(anchor_entry["ancestorsize"])/Decimal(10**8), anchor_entry["fees"]["modified"])
+
 
 if __name__ == '__main__':
     PSBTTest().main()

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -852,6 +852,9 @@ class PSBTTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "PSBTs not compatible (different transactions)", self.nodes[0].combinepsbt, [psbt1, psbt2])
         assert_equal(self.nodes[0].combinepsbt([psbt1, psbt1]), psbt1)
 
+        self.log.info("Test we don't crash when making a 0-value funded transaction at 0 fee without forcing an input selection")
+        assert_raises_rpc_error(-4, "Transaction requires one destination of non-0 value, a non-0 feerate, or a pre-selected input", self.nodes[0].walletcreatefundedpsbt, [], [{"data": "deadbeef"}], 0, {"fee_rate": "0"})
+
 
 if __name__ == '__main__':
     PSBTTest().main()

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -55,7 +55,7 @@ class PSBTTest(BitcoinTestFramework):
         self.extra_args = [
             ["-walletrbf=1", "-addresstype=bech32", "-changetype=bech32"], #TODO: Remove address type restrictions once taproot has psbt extensions
             ["-walletrbf=0", "-changetype=legacy"],
-            []
+            ["-ephemeraldelta=0.00010000"] # 10x higher than default
         ]
         self.supports_cli = False
 
@@ -888,6 +888,11 @@ class PSBTTest(BitcoinTestFramework):
         anchor_txid = self.nodes[0].sendrawtransaction(anchor_tx)
         anchor_entry = self.nodes[0].getmempoolentry(anchor_txid)
         assert_equal(Decimal(anchor_entry["ancestorsize"])/Decimal(10**8), anchor_entry["fees"]["modified"])
+
+        # Check modified fee on node with -ephemeraldelta set
+        self.nodes[2].sendrawtransaction(anchor_tx)
+        anchor_entry_2 = self.nodes[2].getmempoolentry(anchor_txid)
+        assert_equal(anchor_entry["fees"]["modified"] * 10, anchor_entry_2["fees"]["modified"])
 
 
 if __name__ == '__main__':

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -38,6 +38,7 @@ from test_framework.script import (
     CScript,
     LegacySignatureHash,
     LEAF_VERSION_TAPSCRIPT,
+    OP_2,
     OP_NOP,
     OP_RETURN,
     OP_TRUE,
@@ -67,18 +68,18 @@ class MiniWalletMode(Enum):
     witness stack of OP_TRUE, i.e. following an anyone-can-spend policy.
     However, if the transactions need to be modified by the user (e.g. prepending
     scriptSig for testing opcodes that are activated by a soft-fork), or the txs
-    should contain an actual signature, the raw modes RAW_OP_TRUE and RAW_P2PK
+    should contain an actual signature, the raw modes RAW_OP_2 and RAW_P2PK
     can be useful. Summary of modes:
 
                     |      output       |           |  tx is   | can modify |  needs
          mode       |    description    |  address  | standard | scriptSig  | signing
     ----------------+-------------------+-----------+----------+------------+----------
     ADDRESS_OP_TRUE | anyone-can-spend  |  bech32m  |   yes    |    no      |   no
-    RAW_OP_TRUE     | anyone-can-spend  |  - (raw)  |   no     |    yes     |   no
+    RAW_OP_2     | anyone-can-spend  |  - (raw)  |   no     |    yes     |   no
     RAW_P2PK        | pay-to-public-key |  - (raw)  |   yes    |    yes     |   yes
     """
     ADDRESS_OP_TRUE = 1
-    RAW_OP_TRUE = 2
+    RAW_OP_2 = 2
     RAW_P2PK = 3
 
 
@@ -89,8 +90,8 @@ class MiniWallet:
         self._mode = mode
 
         assert isinstance(mode, MiniWalletMode)
-        if mode == MiniWalletMode.RAW_OP_TRUE:
-            self._scriptPubKey = bytes(CScript([OP_TRUE]))
+        if mode == MiniWalletMode.RAW_OP_2:
+            self._scriptPubKey = bytes(CScript([OP_2]))
         elif mode == MiniWalletMode.RAW_P2PK:
             # use simple deterministic private key (k=1)
             self._priv_key = ECKey()
@@ -300,7 +301,7 @@ class MiniWallet:
         utxo_to_spend = utxo_to_spend or self.get_utxo()
         assert fee_rate >= 0
         assert fee >= 0
-        if self._mode in (MiniWalletMode.RAW_OP_TRUE, MiniWalletMode.ADDRESS_OP_TRUE):
+        if self._mode in (MiniWalletMode.RAW_OP_2, MiniWalletMode.ADDRESS_OP_TRUE):
             vsize = Decimal(104)  # anyone-can-spend
         elif self._mode == MiniWalletMode.RAW_P2PK:
             vsize = Decimal(168)  # P2PK (73 bytes scriptSig + 35 bytes scriptPubKey + 60 bytes other)
@@ -315,7 +316,7 @@ class MiniWallet:
         tx.nLockTime = locktime
         if self._mode == MiniWalletMode.RAW_P2PK:
             self.sign_tx(tx)
-        elif self._mode == MiniWalletMode.RAW_OP_TRUE:
+        elif self._mode == MiniWalletMode.RAW_OP_2:
             tx.vin[0].scriptSig = CScript([OP_NOP] * 43)  # pad to identical size
         elif self._mode == MiniWalletMode.ADDRESS_OP_TRUE:
             tx.wit.vtxinwit = [CTxInWitness()]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -341,6 +341,7 @@ BASE_SCRIPTS = [
     'feature_help.py',
     'feature_shutdown.py',
     'wallet_migration.py',
+    'mempool_ephemeral_anchor.py',
     'p2p_ibd_txrelay.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time


### PR DESCRIPTION
Accomplishes part of https://github.com/bitcoin-inquisition/bitcoin/issues/12

via first parts of https://github.com/bitcoin/bitcoin/pull/26403

It *does not* require these new output types to be cleaned up via package relay. That is the rest of the logic left out for future updates. It also does nothing to stop pinning attacks; I rely on the V3 nature of the anchors for that.

Added a couple simple tests and split up the logic more than parent PR.

This along with https://github.com/bitcoin-inquisition/bitcoin/pull/22 would allow my ln-symmetry BOLT transactions to enter the mempool with appropriate fees attached, and I could shortly have examples running in my CLN branch with unilateral closes being handled as appropriate.