### PR TITLE
fuzz: fix script target for CTV

### DIFF
--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -78,6 +78,7 @@ FUZZ_TARGET_INIT(script, initialize_script)
         assert(which_type == TxoutType::PUBKEY ||
                which_type == TxoutType::NONSTANDARD ||
                which_type == TxoutType::NULL_DATA ||
+               which_type == TxoutType::TX_BARE_DEFAULT_CHECK_TEMPLATE_VERIFY_HASH ||
                which_type == TxoutType::MULTISIG);
     }
     if (which_type == TxoutType::NONSTANDARD ||


### PR DESCRIPTION
The fuzz/script.cpp test needs updating for bare CTV being standard.
