### PR TITLE
Implement BIP 347 validation (OP_CAT)

### DIFF
--- a/src/binana/op_cat.json
+++ b/src/binana/op_cat.json
@@ -1,0 +1,9 @@
+{
+    "binana": [2024, 1, 0],
+    "deployment": "OP_CAT",
+    "scriptverify": true,
+    "scriptverify_discourage": true,
+    "opcodes": {
+        "CAT": "0x7e"
+    }
+}

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -520,6 +520,21 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                 case OP_NOP:
                     break;
 
+                case OP_CAT:
+                {
+                    assert(flags & SCRIPT_VERIFY_OP_CAT); // unreachable otherwise
+
+                    if (stack.size() < 2)
+                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                    valtype& vch1 = stacktop(-2);
+                    valtype& vch2 = stacktop(-1);
+                    if (vch1.size() + vch2.size() > MAX_SCRIPT_ELEMENT_SIZE)
+                        return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
+                    vch1.insert(vch1.end(), vch2.begin(), vch2.end());
+                    stack.pop_back();
+                    break;
+                }
+
                 case OP_CHECKLOCKTIMEVERIFY:
                 {
                     if (!(flags & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY)) {

--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -2527,6 +2527,344 @@
 ["0", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "UNSATISFIED_LOCKTIME", "CSV fails if stack top bit 1 << 31 is set and the tx version < 2"],
 ["0x050000000001", "CHECKSEQUENCEVERIFY", "CHECKSEQUENCEVERIFY", "UNSATISFIED_LOCKTIME",
   "CSV fails if stack top bit 1 << 31 is not set, and tx version < 2"],
+["OP_CAT (and related) script verify flag tests"],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT",
+    "OK",
+    "TAPSCRIPT CAT test of OP_CAT flag by calling CAT on an empty stack. This does not error because no OP_CAT verify flag is set so CAT is OP_SUCCESS"
+],
+["OP_CAT functionality tests"],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "INVALID_STACK_OPERATION",
+    "TAPSCRIPT Test of OP_CAT flag by calling CAT on an empty stack. This throws an error because OP_CAT verify flag is set so CAT is executed"
+],
+[
+    [
+        "aa",
+        "bb",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Test of OP_CAT flag by calling CAT on two elements. OP_CAT verify flag is set so CAT is executed."
+],
+[
+    [
+        "78a11a1260c1101260",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT CATs 78a11a1260 and c1101260 together and checks it is EQUAL to stack element 78a11a1260c1101260"
+],
+[
+    [
+        "78a11a1260c1101260",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT",
+    "OK",
+    "TAPSCRIPT Test of OP_CAT flag, CATs 78a11a1260 and c1101260 together and checks it is EQUAL to stack element 78a11a1260c1101260. No OP_CAT verify flag set so CAT should be OP_SUCCESS."
+],
+[
+    [
+        "",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "EVAL_FALSE",
+    "TAPSCRIPT CATs 78a11a1260 and c1101260 together and checks it is EQUAL to the empty stack element"
+],
+[
+    [
+        "51",
+        "78a11a1260c1101260",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUALVERIFY",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT CATS 78a11a1260 and c1101260 together and checks it is EQUALVERIFY to stack element 78a11a1260c1101260"
+],
+[
+    [
+        "51",
+        "c110126078a11a1260",
+        "78a11a1260",
+        "c1101260",
+        "#SCRIPT# CAT EQUALVERIFY",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "EQUALVERIFY",
+    "TAPSCRIPT CATs 78a11a1260 and c1101260 together and checks it is EQUALVERIFY to stack element c110126078a11a1260"
+],
+[
+    [
+        "aa",
+        "bb",
+        "#SCRIPT# CAT 0x4c 0x02 0xaabb EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT CATs aa and bb together and checks EQUAL to aabb"
+],
+[
+    [
+        "eeffeeff",
+        "aa",
+        "bbff",
+        "#SCRIPT# CAT CAT DUP DROP 0x4c 0x07 0xeeffeeffaabbff EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT CATs aa and bbcc and eeffeff together and checks EQUAL to eeffeeffaabbcc"
+],
+[
+    [
+        "c24f2c1e363e09a5dd56f0",
+        "89a0385490a11b6dc6740f3513",
+        "#SCRIPT# CAT 0x4c 0x18 0xc24f2c1e363e09a5dd56f089a0385490a11b6dc6740f3513 EQUAL",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Tests CAT on different sized random stack elements and compares the result."
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93",
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Tests CAT on two hash outputs"
+],
+[
+    [
+        "51",
+        "bbbb",
+        "01",
+        "#SCRIPT# IF CAT ELSE DROP ENDIF",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Tests CAT inside of an IF ELSE conditional (true IF)"
+],
+[
+    [
+        "51",
+        "",
+        "#SCRIPT# IF CAT ELSE DROP ENDIF",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "CLEANSTACK",
+    "TAPSCRIPT Tests CAT inside of an IF ELSE conditional (false IF)"
+],
+[
+    [
+        "1a1a",
+        "#SCRIPT# DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Runs DUP CAT seven times on 1a1a"
+],
+[
+    [
+        "1a1a1a1a1a1a1a",
+        "#SCRIPT# DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT DUP CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "PUSH_SIZE",
+    "TAPSCRIPT Runs DUP CAT seven times on 1a1a1a1a1a1a1a triggering a stack size error as the result is larger than max stack element size"
+],
+[
+    [
+        "1ffe1234567890",
+        "00",
+        "#SCRIPT# HASH256 DUP SHA1 CAT DUP CAT TOALTSTACK HASH256 DUP CAT TOALTSTACK FROMALTSTACK",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT Tests CAT with a melange of other opcodes including FROMALTSTACK. "
+],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "INVALID_STACK_OPERATION",
+    "TAPSCRIPT ([], CAT) Tests CAT fails on empty stack"
+],
+[
+    [
+        "09ca7009ca7009ca7009ca7009ca70",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "INVALID_STACK_OPERATION",
+    "TAPSCRIPT ([09ca7009ca7009ca7009ca7009ca70], CAT) Tests CAT fails on a stack of only one element"
+],
+[
+    [
+        "",
+        "09ca7009ca7009ca7009ca7009ca70",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT (['', 09ca7009ca7009ca7009ca7009ca70], CAT) Tests CAT succeeds when one of the two values to concatenate is of size zero"
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93",
+        "0102030405060708",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "OK",
+    "TAPSCRIPT ([512 byte element, 09ca7009ca7009ca7009ca7009ca70], CAT) Tests edge case where concatenated value is exactly max stack element size (520 bytes)"
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b930102030405060708",
+        "01",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "PUSH_SIZE",
+    "TAPSCRIPT ([520 byte element, 01], CAT) Tests edge case where concatenated value is one byte larger than max stack element size (520 bytes)"
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b930102030405060708",
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b930102030405060708",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "PUSH_SIZE",
+    "TAPSCRIPT ([520 byte element, 520 byte element], CAT) Tests case where each element to concatenate is exactly max stack element size (520 bytes)"
+],
+[
+    [
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b930102030405060708",
+        "f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93f821125522f9490bcd108cdd0effbb002d45c6e66e6b48aeb51c865743796b93010203040506070809",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT",
+    "PUSH_SIZE",
+    "TAPSCRIPT ([520 byte element, 521 byte element], CAT) Tests edge case where one of the elements to concatenate is one byte larger than max stack element size (520 bytes)"
+],
 
 ["MINIMALIF tests"],
 ["MINIMALIF is not applied to non-segwit scripts"],

--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -2540,6 +2540,82 @@
     "OK",
     "TAPSCRIPT CAT test of OP_CAT flag by calling CAT on an empty stack. This does not error because no OP_CAT verify flag is set so CAT is OP_SUCCESS"
 ],
+[
+    [
+        "aa",
+        "bb",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT,OP_CAT",
+    "DISCOURAGE_OP_CAT",
+    "TAPSCRIPT test of DISCOURAGE_OP_CAT flag by calling CAT on two elements. OP_CAT verify flag is set however OP_CAT is not executed due to DISCOURAGE_OP_CAT."
+],
+[
+    [
+        "aa",
+        "bb",
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT",
+    "DISCOURAGE_OP_CAT",
+    "TAPSCRIPT test of DISCOURAGE_OP_CAT flag by calling CAT on two elements. OP_CAT verify flag is not set and OP_CAT is not executed due to DISCOURAGE_OP_CAT."
+],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT",
+    "DISCOURAGE_OP_CAT",
+    "TAPSCRIPT test of DISCOURAGE_OP_CAT flag by calling CAT on a empty stack. Ordinarily this would be INVALID_STACK_OPERATION however due to DISCOURAGE_OP_CAT the script will throw before execution."
+],
+[
+    [
+        "#SCRIPT# 1",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT",
+    "OK",
+    "TAPSCRIPT test of a valid script executed with DISCOURAGE_OP_CAT. This tests demonstrates that DISCOURAGE_OP_CAT has no affect when CAT is not used."
+],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,DISCOURAGE_OP_CAT,DISCOURAGE_OP_SUCCESS",
+    "DISCOURAGE_OP_CAT",
+    "TAPSCRIPT test of a invalid script (CAT called with empty stack) executed with DISCOURAGE_OP_CAT and DISCOURAGE_OP_SUCCESS flags enabled. This tests demonstrates that DISCOURAGE_OP_CAT will take priority over the OP_SUCCESS discourage flag and OP_CAT is never exectuted"
+],
+[
+    [
+        "#SCRIPT# CAT",
+        "#CONTROLBLOCK#",
+        0.00000001
+    ],
+    "",
+    "0x51 0x20 #TAPROOTOUTPUT#",
+    "P2SH,WITNESS,TAPROOT,OP_CAT,DISCOURAGE_OP_SUCCESS",
+    "INVALID_STACK_OPERATION",
+    "TAPSCRIPT CAT on no stack elements with DISCOURAGE_OP_SUCCESS and OP_CAT script verify flags enabled. This test demonstrates that OP_CAT is no longer considered OP_SUCCESS when OP_CAT verify flag is set"
+],
 ["OP_CAT functionality tests"],
 [
     [

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -924,16 +924,34 @@ BOOST_AUTO_TEST_CASE(script_json_test)
     // amount (nValue) to use in the crediting tx
     UniValue tests = read_json(json_tests::script_tests);
 
+    const KeyData keys;
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         const UniValue& test = tests[idx];
         std::string strTest = test.write();
         CScriptWitness witness;
+        TaprootBuilder taprootBuilder;
         CAmount nValue = 0;
         unsigned int pos = 0;
         if (test.size() > 0 && test[pos].isArray()) {
             unsigned int i=0;
             for (i = 0; i < test[pos].size()-1; i++) {
-                witness.stack.push_back(ParseHex(test[pos][i].get_str()));
+                auto element = test[pos][i].get_str();
+                // We use #SCRIPT# to flag a non-hex script that we can read using ParseScript
+                // Taproot script must be third from the last element in witness stack
+                std::string scriptFlag = std::string("#SCRIPT#");
+                if (element.find(scriptFlag) == 0) {
+                    CScript script = ParseScript(element.substr(scriptFlag.size()));
+                    witness.stack.push_back(ToByteVector(script));
+                } else if (strcmp(element.c_str(), "#CONTROLBLOCK#") == 0) {
+                    // Taproot script control block - second from the last element in witness stack
+                    // If #CONTROLBLOCK# we auto-generate the control block
+                    taprootBuilder.Add(/*depth=*/0, witness.stack.back(), TAPROOT_LEAF_TAPSCRIPT, /*track=*/true);
+                    taprootBuilder.Finalize(XOnlyPubKey(keys.key0.GetPubKey()));
+                    auto controlblocks = taprootBuilder.GetSpendData().scripts[{witness.stack.back(), TAPROOT_LEAF_TAPSCRIPT}];
+                    witness.stack.push_back(*(controlblocks.begin()));
+                } else {
+                    witness.stack.push_back(ParseHex(element));
+                }
             }
             nValue = AmountFromValue(test[pos][i]);
             pos++;
@@ -948,7 +966,14 @@ BOOST_AUTO_TEST_CASE(script_json_test)
         std::string scriptSigString = test[pos++].get_str();
         CScript scriptSig = ParseScript(scriptSigString);
         std::string scriptPubKeyString = test[pos++].get_str();
-        CScript scriptPubKey = ParseScript(scriptPubKeyString);
+        CScript scriptPubKey;
+        // If requested, auto-generate the taproot output
+        if (strcmp(scriptPubKeyString.c_str(), "0x51 0x20 #TAPROOTOUTPUT#")== 0) {
+            BOOST_CHECK_MESSAGE(taprootBuilder.IsComplete(), "Failed to autogenerate Tapscript Script PubKey");
+            scriptPubKey = CScript() << OP_1 << ToByteVector(taprootBuilder.GetOutput());
+        } else {
+            scriptPubKey = ParseScript(scriptPubKeyString);
+        }
         unsigned int scriptflags = ParseScriptFlags(test[pos++].get_str());
         int scriptError = ParseScriptError(test[pos++].get_str());
 
@@ -1738,6 +1763,77 @@ BOOST_AUTO_TEST_CASE(formatscriptflags)
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH | (1u<<31)), "P2SH,0x80000000");
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | (1u<<31)), "TAPROOT,0x80000000");
     BOOST_CHECK_EQUAL(FormatScriptFlags(1u<<31), "0x80000000");
+}
+
+
+void DoTapscriptTest(ScriptTest& test, std::vector<unsigned char> witVerifyScript, std::vector<std::vector<unsigned char>> witData, const std::string& message, int scriptError)
+{
+    const KeyData keys;
+    TaprootBuilder builder;
+    builder.Add(/*depth=*/0, witVerifyScript, TAPROOT_LEAF_TAPSCRIPT, /*track=*/true);
+    builder.Finalize(XOnlyPubKey(keys.key0.GetPubKey()));
+
+    CScriptWitness witness;
+    witness.stack.insert(witness.stack.begin(), witData.begin(), witData.end());
+    witness.stack.push_back(witVerifyScript);
+    auto controlblock = *(builder.GetSpendData().scripts[{witVerifyScript, TAPROOT_LEAF_TAPSCRIPT}].begin());
+    witness.stack.push_back(controlblock);
+
+    uint32_t flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_OP_CAT;
+    CScript scriptPubKey = CScript() << OP_1 << ToByteVector(builder.GetOutput());
+    CScript scriptSig = CScript(); // Script sig is always size 0 and empty in tapscript
+    test.DoTest(scriptPubKey, scriptSig, witness, flags, message, scriptError, /*nValue=*/1);
+}
+
+BOOST_AUTO_TEST_CASE(cat_simple)
+{
+    std::vector<std::vector<unsigned char>> witData;
+    witData.push_back(ParseHex("aa"));
+    witData.push_back(ParseHex("bbbb"));
+    std::vector<unsigned char> witVerifyScript = {OP_CAT, OP_PUSHDATA1, 0x03, 0xaa, 0xbb, 0xbb, OP_EQUAL};
+    DoTapscriptTest(*this, witVerifyScript, witData, "Simple CAT", SCRIPT_ERR_OK);
+}
+
+
+BOOST_AUTO_TEST_CASE(cat_empty_stack)
+{
+    // Ensures that OP_CAT successfully handles concatenating two empty stack elements
+    std::vector<std::vector<unsigned char>> witData;
+    witData.push_back({});
+    witData.push_back({});
+    std::vector<unsigned char> witVerifyScript = {OP_CAT, OP_PUSHDATA1, 0x00,OP_EQUAL};
+    DoTapscriptTest(*this, witVerifyScript, witData, "CAT empty stack", SCRIPT_ERR_OK);
+}
+
+BOOST_AUTO_TEST_CASE(cat_dup_test)
+{
+    // CAT DUP exhaustion attacks using all element sizes from 1 to 522
+    // with CAT DUP repetitions up to 10. Ensures the correct error is thrown
+    // or not thrown, as appropriate.
+    unsigned int maxElementSize = 522;
+    unsigned int maxDupsToCheck = 10;
+
+    std::vector<std::vector<unsigned char>> witData;
+    witData.push_back({});
+    for (unsigned int elementSize = 1; elementSize <= maxElementSize; elementSize++) {
+        std::vector<unsigned char> witVerifyScript;
+        // increase the size of stack element by one byte
+        witData.at(0).push_back(0x1A);
+        for (unsigned int dups = 1; dups <= maxDupsToCheck; dups++) {
+            witVerifyScript.push_back(OP_DUP);
+            witVerifyScript.push_back(OP_CAT);
+            int expectedErr = SCRIPT_ERR_OK;
+            unsigned int catedStackElementSize = witData.at(0).size()<<dups;
+            if (catedStackElementSize > MAX_SCRIPT_ELEMENT_SIZE || elementSize > MAX_SCRIPT_ELEMENT_SIZE){
+                expectedErr = SCRIPT_ERR_PUSH_SIZE;
+                break;
+            }
+            DoTapscriptTest(*this, witVerifyScript, witData, "CAT DUP test", expectedErr);
+            // Once we hit the stack element size limit, break
+            if (expectedErr == SCRIPT_ERR_OK)
+                break;
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_opcat.py
+++ b/test/functional/feature_opcat.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2024 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test (OP_CAT)
+"""
+
+from test_framework.blocktools import (
+    create_coinbase,
+    create_block,
+    add_witness_commitment,
+)
+from test_framework.messages import (
+    CTransaction,
+    CTxOut,
+    CTxIn,
+    CTxInWitness,
+    COutPoint,
+    COIN,
+    sha256,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.script import (
+    CScript,
+    OP_CAT,
+    OP_EQUAL,
+    OP_2,
+    OP_DUP,
+    taproot_construct,
+)
+from test_framework.script_util import script_to_p2sh_script
+from test_framework.key import ECKey, compute_xonly_pubkey
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.wallet import MiniWallet, MiniWalletMode
+from decimal import Decimal
+import random
+from io import BytesIO
+from test_framework.address import script_to_p2sh
+
+DISCOURAGED_ERROR = (
+    "non-mandatory-script-verify-flag (NOPx reserved for soft-fork upgrades)"
+)
+STACK_TOO_SHORT_ERROR = (
+    "non-mandatory-script-verify-flag (Operation not valid with the current stack size)"
+)
+DISABLED_OP_CODE = (
+    "mandatory-script-verify-flag-failed (Attempted to use a disabled opcode)"
+)
+MAX_PUSH_ERROR = (
+    "non-mandatory-script-verify-flag (Push value size limit exceeded)"
+)
+
+def random_bytes(n):
+    return bytes(random.getrandbits(8) for i in range(n))
+
+
+def random_p2sh():
+    return script_to_p2sh_script(random_bytes(20))
+
+
+def create_transaction_to_script(node, wallet, txid, script, *, amount_sats):
+    """Return signed transaction spending the first output of the
+    input txid. Note that the node must be able to sign for the
+    output that is being spent, and the node must not be running
+    multiple wallets.
+    """
+    random_address = script_to_p2sh(CScript())
+    output = wallet.get_utxo(txid=txid)
+    rawtx = node.createrawtransaction(
+        inputs=[{"txid": output["txid"], "vout": output["vout"]}],
+        outputs={random_address: Decimal(amount_sats) / COIN},
+    )
+    tx = CTransaction()
+    tx.deserialize(BytesIO(bytes.fromhex(rawtx)))
+    # Replace with our script
+    tx.vout[0].scriptPubKey = script
+    # Sign
+    wallet.sign_tx(tx)
+    return tx
+
+
+class CatTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [
+            ["-par=1"]
+        ]  # Use only one script thread to get the exact reject reason for testing
+        self.setup_clean_chain = True
+        self.rpc_timeout = 120
+
+    def get_block(self, txs):
+        self.tip = self.nodes[0].getbestblockhash()
+        self.height = self.nodes[0].getblockcount()
+        self.log.debug(self.height)
+        block = create_block(
+            int(self.tip, 16), create_coinbase(self.height + 1))
+        block.vtx.extend(txs)
+        add_witness_commitment(block)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        return block.serialize(True).hex(), block.hash
+
+    def add_block(self, txs):
+        block, h = self.get_block(txs)
+        reason = self.nodes[0].submitblock(block)
+        if reason:
+            self.log.debug("Reject Reason: [%s]", reason)
+        assert_equal(self.nodes[0].getbestblockhash(), h)
+        return h
+
+    def run_test(self):
+        # The goal is to test a number of circumstances and combinations of parameters. Roughly:
+        #
+        #   - Taproot OP_CAT
+        #     - CAT should fail when stack limit is hit
+        #     - CAT should fail if there is insuffecient number of element on the stack
+        #     - CAT should be able to concatenate two 8 byte payloads and check the resulting 16 byte payload
+        #  - Segwit v0 OP_CAT
+        #     - Spend should fail due to using disabled opcodes
+
+        wallet = MiniWallet(self.nodes[0], mode=MiniWalletMode.RAW_P2PK)
+        self.nodes[0].add_p2p_connection(P2PInterface())
+
+        BLOCKS = 200
+        self.log.info("Mining %d blocks for mature coinbases", BLOCKS)
+        # Drop the last 100 as they're unspendable!
+        coinbase_txids = [
+            self.nodes[0].getblock(b)["tx"][0]
+            for b in self.generate(wallet, BLOCKS)[:-100]
+        ]
+        def get_coinbase(): return coinbase_txids.pop()
+        self.log.info("Creating setup transactions")
+
+        outputs = [CTxOut(i * 1000, random_p2sh()) for i in range(1, 11)]
+        # Add some fee satoshis
+        amount_sats = sum(out.nValue for out in outputs) + 200 * 500
+
+        self.log.info(
+            "Creating funding txn for 10 random outputs as a Taproot script")
+        private_key = ECKey()
+        # use simple deterministic private key (k=1)
+        private_key.set((1).to_bytes(32, "big"), False)
+        assert private_key.is_valid
+        public_key, _ = compute_xonly_pubkey(private_key.get_bytes())
+
+        self.log.info(
+            "Creating CAT tx with not enough values on the stack")
+        not_enough_stack_elements_script = CScript([OP_CAT, OP_EQUAL, OP_2])
+        taproot_not_enough_stack_elements = taproot_construct(
+            public_key, [("only-path", not_enough_stack_elements_script, 0xC0)])
+        taproot_not_enough_stack_elements_funding_tx = create_transaction_to_script(
+            self.nodes[0],
+            wallet,
+            get_coinbase(),
+            taproot_not_enough_stack_elements.scriptPubKey,
+            amount_sats=amount_sats,
+        )
+
+        self.log.info(
+            "Creating CAT tx that exceeds the stack element limit size")
+        # Convert hex value to bytes
+        hex_bytes = bytes.fromhex(('00' * 8))
+        stack_limit_script = CScript(
+            [
+                hex_bytes,
+                OP_DUP,
+                OP_CAT,
+                # 16 bytes on the stack
+                OP_DUP,
+                OP_CAT,
+                # 32 bytes on the stack
+                OP_DUP,
+                OP_CAT,
+                # 64 bytes on the stack
+                OP_DUP,
+                OP_CAT,
+                # 128 bytes on the stack
+                OP_DUP,
+                OP_CAT,
+                # 256 bytes on the stack
+                OP_DUP,
+                OP_CAT,
+                # 512 bytes on the stack
+                OP_DUP,
+                OP_CAT,
+            ])
+
+        taproot_stack_limit = taproot_construct(
+            public_key, [("only-path", stack_limit_script, 0xC0)])
+        taproot_stack_limit_funding_tx = create_transaction_to_script(
+            self.nodes[0],
+            wallet,
+            get_coinbase(),
+            taproot_stack_limit.scriptPubKey,
+            amount_sats=amount_sats,
+        )
+        self.log.info(
+            "Creating CAT tx that concatenates to values and verifies")
+        hex_value_verify = bytes.fromhex('00' * 16)
+        op_cat_verify_script = CScript([
+            hex_bytes,
+            OP_DUP,
+            OP_CAT,
+            hex_value_verify,
+            OP_EQUAL,
+        ])
+
+        taproot_op_cat = taproot_construct(
+            public_key, [("only-path", op_cat_verify_script, 0xC0)])
+        taproot_op_cat_funding_tx = create_transaction_to_script(
+            self.nodes[0],
+            wallet,
+            get_coinbase(),
+            taproot_op_cat.scriptPubKey,
+            amount_sats=amount_sats,
+        )
+
+        self.log.info("Creating a CAT segwit funding tx")
+        segwit_cat_funding_tx = create_transaction_to_script(
+            self.nodes[0],
+            wallet,
+            get_coinbase(),
+            CScript([0, sha256(op_cat_verify_script)]),
+            amount_sats=amount_sats,
+        )
+
+        funding_txs = [
+            taproot_not_enough_stack_elements_funding_tx,
+            taproot_stack_limit_funding_tx,
+            taproot_op_cat_funding_tx,
+            segwit_cat_funding_tx,
+        ]
+        self.log.info("Obtaining TXIDs")
+        (
+            taproot_not_enough_stack_elements_outpoint,
+            taproot_stack_limit_outpoint,
+            taproot_op_cat_outpoint,
+            segwit_op_cat_outpoint,
+        ) = [COutPoint(int(tx.rehash(), 16), 0) for tx in funding_txs]
+
+        self.log.info("Funding all outputs")
+        self.add_block(funding_txs)
+
+        self.log.info("Testing Taproot not enough stack elements OP_CAT spend")
+        # Test sendrawtransaction
+        taproot_op_cat_not_enough_stack_elements_spend = CTransaction()
+        taproot_op_cat_not_enough_stack_elements_spend.version = 2
+        taproot_op_cat_not_enough_stack_elements_spend.vin = [
+            CTxIn(taproot_not_enough_stack_elements_outpoint)]
+        taproot_op_cat_not_enough_stack_elements_spend.vout = outputs
+        taproot_op_cat_not_enough_stack_elements_spend.wit.vtxinwit += [
+            CTxInWitness()]
+        taproot_op_cat_not_enough_stack_elements_spend.wit.vtxinwit[0].scriptWitness.stack = [
+            not_enough_stack_elements_script,
+            bytes([0xC0 + taproot_not_enough_stack_elements.negflag]) +
+            taproot_not_enough_stack_elements.internal_pubkey,
+        ]
+
+        assert_raises_rpc_error(
+            -26,
+            STACK_TOO_SHORT_ERROR,
+            self.nodes[0].sendrawtransaction,
+            taproot_op_cat_not_enough_stack_elements_spend.serialize().hex(),
+        )
+        self.log.info(
+            "OP_CAT with wrong size stack rejected by sendrawtransaction as discouraged"
+        )
+
+        self.log.info("Testing Taproot tx with stack element size limit")
+        taproot_op_cat_stack_limit_spend = CTransaction()
+        taproot_op_cat_stack_limit_spend.version = 2
+        taproot_op_cat_stack_limit_spend.vin = [
+            CTxIn(taproot_stack_limit_outpoint)]
+        taproot_op_cat_stack_limit_spend.vout = outputs
+        taproot_op_cat_stack_limit_spend.wit.vtxinwit += [
+            CTxInWitness()]
+        taproot_op_cat_stack_limit_spend.wit.vtxinwit[0].scriptWitness.stack = [
+            stack_limit_script,
+            bytes([0xC0 + taproot_stack_limit.negflag]) +
+            taproot_stack_limit.internal_pubkey,
+        ]
+
+        assert_raises_rpc_error(
+            -26,
+            MAX_PUSH_ERROR,
+            self.nodes[0].sendrawtransaction,
+            taproot_op_cat_stack_limit_spend.serialize().hex(),
+        )
+        self.log.info(
+            "OP_CAT with stack size limit rejected by sendrawtransaction as discouraged"
+        )
+
+        self.log.info("Testing Taproot OP_CAT usage")
+        taproot_op_cat_transaction = CTransaction()
+        taproot_op_cat_transaction.version = 2
+        taproot_op_cat_transaction.vin = [
+            CTxIn(taproot_op_cat_outpoint)]
+        taproot_op_cat_transaction.vout = outputs
+        taproot_op_cat_transaction.wit.vtxinwit += [
+            CTxInWitness()]
+        taproot_op_cat_transaction.wit.vtxinwit[0].scriptWitness.stack = [
+            op_cat_verify_script,
+            bytes([0xC0 + taproot_op_cat.negflag]) +
+            taproot_op_cat.internal_pubkey,
+        ]
+
+        assert_equal(
+            self.nodes[0].sendrawtransaction(
+                taproot_op_cat_transaction.serialize().hex()),
+            taproot_op_cat_transaction.rehash(),
+        )
+        self.log.info(
+            "Taproot OP_CAT verify spend accepted by sendrawtransaction"
+        )
+        self.add_block([taproot_op_cat_transaction])
+
+        self.log.info("Testing Segwitv0 CAT usage")
+        segwitv0_op_cat_transaction = CTransaction()
+        segwitv0_op_cat_transaction.version = 2
+        segwitv0_op_cat_transaction.vin = [
+            CTxIn(segwit_op_cat_outpoint)]
+        segwitv0_op_cat_transaction.vout = outputs
+        segwitv0_op_cat_transaction.wit.vtxinwit += [
+            CTxInWitness()]
+        segwitv0_op_cat_transaction.wit.vtxinwit[0].scriptWitness.stack = [
+            op_cat_verify_script,
+        ]
+
+        assert_raises_rpc_error(
+            -26,
+            DISABLED_OP_CODE,
+            self.nodes[0].sendrawtransaction,
+            segwitv0_op_cat_transaction.serialize().hex(),
+        )
+        self.log.info(
+            "allowed by consensus, disallowed by relay policy"
+        )
+
+
+if __name__ == "__main__":
+    CatTest(__file__).main()

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -937,4 +937,7 @@ def taproot_construct(pubkey, scripts=None, treat_internal_as_infinity=False):
     return TaprootInfo(CScript([OP_1, tweaked]), pubkey, negated + 0, tweak, leaves, h, tweaked)
 
 def is_op_success(o):
+    if o in [OP_CAT]:
+        return False
+
     return o == 0x50 or o == 0x62 or o == 0x89 or o == 0x8a or o == 0x8d or o == 0x8e or (o >= 0x7e and o <= 0x81) or (o >= 0x83 and o <= 0x86) or (o >= 0x95 and o <= 0x99) or (o >= 0xbb and o <= 0xfe)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -326,6 +326,7 @@ BASE_SCRIPTS = [
     'wallet_listsinceblock.py --legacy-wallet',
     'wallet_listsinceblock.py --descriptors',
     'wallet_listdescriptors.py --descriptors',
+    'feature_opcat.py',
     'p2p_leak.py',
     'wallet_encryption.py --legacy-wallet',
     'wallet_encryption.py --descriptors',


### PR DESCRIPTION
Forward port from #68 (with test fixes from #75 by darosior), updated to use `binana/op_cat.json` to get rid of a bunch of the soft-fork boiler plate.