### PR TITLE
Allow configuring target block time for a signet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,6 +117,15 @@ void ReadSigNetArgs(const ArgsManager& args, CChainParams::SigNetOptions& option
         }
         options.challenge.emplace(*val);
     }
+    if (const auto signetblocktime{args.GetIntArg("-signetblocktime")}) {
+        if (!args.IsArgSet("-signetchallenge")) {
+            throw std::runtime_error("-signetblocktime cannot be set without -signetchallenge");
+        }
+        if (*signetblocktime <= 0) {
+            throw std::runtime_error("-signetblocktime must be greater than 0");
+        }
+        options.pow_target_spacing = *signetblocktime;
+    }
     HandleRenounceArgs(args, options.renounce);
 }
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -23,6 +23,7 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-renounce=deployment", "Unconditionally disable an heretical deployment attempt", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signet", "Use the signet chain. Equivalent to -chain=signet. Note that the network is defined by the -signetchallenge parameter", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-signetblocktime", "Difficulty adjustment will target a block time of the given amount in seconds (only for custom signet networks, must have -signetchallenge set; defaults to 10 minutes/600 seconds)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signetseednode", "Specify a seed node for the signet network, in the hostname[:port] format, e.g. sig.net:1234 (may be used multiple times to specify multiple seed nodes; defaults to the global default signet test network seed node(s))", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
 }
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -521,7 +521,7 @@ public:
         consensus.SegwitHeight = 1;
         consensus.TaprootHeight = 1;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetSpacing = options.pow_target_spacing;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.enforce_BIP94 = false;
         consensus.fPowNoRetargeting = false;

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -158,6 +158,7 @@ public:
         DeploymentOptions dep_opts{};
         std::optional<std::vector<uint8_t>> challenge{};
         std::optional<std::vector<std::string>> seeds{};
+        int64_t pow_target_spacing{10 * 60};
         RenounceParameters renounce{};
     };
 


### PR DESCRIPTION
I plan to move mutinynet to use inquisition. Merging this would make my life easier but if you don't want to merge I understand!