### PR TITLE
 Bump SCRIPT_VERIFY flags to 64 bit

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -24,7 +24,7 @@ static void VerifyScriptBench(benchmark::Bench& bench)
 {
     ECC_Context ecc_context{};
 
-    const uint32_t flags{SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH};
+    const script_verify_flags flags{SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH};
     const int witnessversion = 0;
 
     // Key pair.

--- a/src/binana.py
+++ b/src/binana.py
@@ -45,7 +45,7 @@ def get_binana_info(path):
     return data
 
 def gen_binana_h(data, header, depjson):
-    script_verify_bit = 30 # count backwards; 31 is assumed unused in unit tests
+    script_verify_bit = 60 # count backwards; note: 63 is assumed unused in unit tests
 
     defines = {a: [] for a in "DEPLOYMENTS DEPLOYMENTS_SIGNET DEPLOYMENTS_REGTEST DEPLOYMENTS_GBT VERIFY_FLAGS VERIFY_FLAGS_NAMES STANDARD_VERIFY_FLAGS OPCODES OPCODE_NAMES SUCCESS_OPCODES SCRIPTERR SCRIPTERR_STRING SCRIPTERR_TEST_NAMES CONSENSUS_CHECKS POLICY_CHECKS".split()}
 
@@ -90,7 +90,7 @@ def gen_binana_h(data, header, depjson):
         if b.get("scriptverify", False):
             jsoninfo["script_flags"].append(dep)
 
-            defines["VERIFY_FLAGS"].append(f'SCRIPT_VERIFY_{dep} = (1U << {script_verify_bit}),')
+            defines["VERIFY_FLAGS"].append(f'SCRIPT_VERIFY_{dep} = (1ULL << {script_verify_bit}),')
             script_verify_bit -= 1
 
             defines["VERIFY_FLAGS_NAMES"].append(f'{{ "{dep}", SCRIPT_VERIFY_{dep} }},')
@@ -102,7 +102,7 @@ def gen_binana_h(data, header, depjson):
         discourage = False
         if b.get("scriptverify", False) and b.get("scriptverify_discourage", False):
             discourage = True
-            defines["VERIFY_FLAGS"].append(f'SCRIPT_VERIFY_DISCOURAGE_{dep} = (1U << {script_verify_bit}),')
+            defines["VERIFY_FLAGS"].append(f'SCRIPT_VERIFY_DISCOURAGE_{dep} = (1ULL << {script_verify_bit}),')
             script_verify_bit -= 1
 
             defines["VERIFY_FLAGS_NAMES"].append(f'{{ "DISCOURAGE_{dep}", SCRIPT_VERIFY_DISCOURAGE_{dep} }},')

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -183,13 +183,13 @@ static std::string sigver2str(SigVersion sigver)
     return "unknown";
 }
 
-static uint32_t parse_verify_flags(const std::string& strFlags)
+static script_verify_flags parse_verify_flags(const std::string& strFlags)
 {
     if (strFlags.empty() || strFlags == "MANDATORY") return MANDATORY_SCRIPT_VERIFY_FLAGS;
     if (strFlags == "STANDARD") return STANDARD_SCRIPT_VERIFY_FLAGS;
     if (strFlags == "NONE") return 0;
 
-    unsigned int flags = 0;
+    script_verify_flags flags = 0;
     std::vector<std::string> words = util::SplitString(strFlags, ',');
 
     for (const std::string& word : words)
@@ -220,7 +220,7 @@ static int EvalScript(const ArgsManager& argsman, const std::vector<std::string>
 {
     UniValue result{UniValue::VOBJ};
 
-    uint32_t flags{0};
+    script_verify_flags flags{0};
     PrecomputedTransactionData txdata;
     ScriptExecutionData execdata;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -7,6 +7,7 @@
 #define BITCOIN_CONSENSUS_PARAMS_H
 
 #include <binana.h>
+#include <script/verify_flags.h>
 #include <uint256.h>
 
 #include <array>
@@ -83,7 +84,7 @@ struct Params {
      * - buried in the chain, and
      * - fail if the default script verify flags are applied.
      */
-    std::map<uint256, uint32_t> script_flag_exceptions;
+    std::map<uint256, script_verify_flags> script_flag_exceptions;
     /** Block height and hash at which BIP34 becomes active */
     int BIP34Height;
     uint256 BIP34Hash;

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -140,7 +140,7 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& in
     return nSigOps;
 }
 
-int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& inputs, uint32_t flags)
+int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& inputs, script_verify_flags flags)
 {
     int64_t nSigOps = GetLegacySigOpCount(tx) * WITNESS_SCALE_FACTOR;
 

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -6,6 +6,7 @@
 #define BITCOIN_CONSENSUS_TX_VERIFY_H
 
 #include <consensus/amount.h>
+#include <script/verify_flags.h>
 
 #include <stdint.h>
 #include <vector>
@@ -52,7 +53,7 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& ma
  * @param[in] flags Script verification flags
  * @return Total signature operation cost of tx
  */
-int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& inputs, uint32_t flags);
+int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& inputs, script_verify_flags flags);
 
 /**
  * Check if transaction is final and can be included in a block with the

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -83,13 +83,13 @@ const std::map<std::string, uint32_t> g_verify_flag_names{
 };
 #undef FLAG_NAME
 
-std::vector<std::string> GetScriptFlagNames(uint32_t flags)
+std::vector<std::string> GetScriptFlagNames(script_verify_flags flags)
 {
     std::vector<std::string> res;
     if (flags == SCRIPT_VERIFY_NONE) {
         return res;
     }
-    uint32_t leftover = flags;
+    script_verify_flags leftover = flags;
     for (const auto& [name, flag] : g_verify_flag_names) {
         if ((flags & flag) != 0) {
             res.push_back(name);

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -56,7 +56,7 @@ std::optional<Consensus::BuriedDeployment> GetBuriedDeployment(const std::string
 }
 
 #define FLAG_NAME(flag) {std::string(#flag), SCRIPT_VERIFY_##flag}
-const std::map<std::string, uint32_t> g_verify_flag_names{
+const std::map<std::string, script_verify_flag_name> g_verify_flag_names{
     FLAG_NAME(P2SH),
     FLAG_NAME(STRICTENC),
     FLAG_NAME(DERSIG),
@@ -97,7 +97,7 @@ std::vector<std::string> GetScriptFlagNames(script_verify_flags flags)
         }
     }
     if (leftover != 0) {
-        res.push_back(strprintf("0x%08x", leftover));
+        res.push_back(strprintf("0x%08x", leftover.as_int()));
     }
     return res;
 }

--- a/src/deploymentinfo.h
+++ b/src/deploymentinfo.h
@@ -6,6 +6,7 @@
 #define BITCOIN_DEPLOYMENTINFO_H
 
 #include <consensus/params.h>
+#include <script/verify_flags.h>
 
 #include <array>
 #include <cassert>
@@ -36,6 +37,6 @@ std::optional<Consensus::BuriedDeployment> GetBuriedDeployment(const std::string
 
 extern const std::map<std::string, uint32_t> g_verify_flag_names;
 
-std::vector<std::string> GetScriptFlagNames(uint32_t flags);
+std::vector<std::string> GetScriptFlagNames(script_verify_flags flags);
 
 #endif // BITCOIN_DEPLOYMENTINFO_H

--- a/src/deploymentinfo.h
+++ b/src/deploymentinfo.h
@@ -35,7 +35,7 @@ inline std::string DeploymentName(Consensus::DeploymentPos pos)
 
 std::optional<Consensus::BuriedDeployment> GetBuriedDeployment(const std::string_view deployment_name);
 
-extern const std::map<std::string, uint32_t> g_verify_flag_names;
+extern const std::map<std::string, script_verify_flag_name> g_verify_flag_names;
 
 std::vector<std::string> GetScriptFlagNames(script_verify_flags flags);
 

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -99,7 +99,7 @@ static constexpr unsigned int MAX_DUST_OUTPUTS_PER_TX{1};
  * Note that this does not affect consensus validity; see GetBlockScriptFlags()
  * for that.
  */
-static constexpr unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS{SCRIPT_VERIFY_P2SH |
+static constexpr script_verify_flags MANDATORY_SCRIPT_VERIFY_FLAGS{SCRIPT_VERIFY_P2SH |
                                                              SCRIPT_VERIFY_DERSIG |
                                                              SCRIPT_VERIFY_NULLDUMMY |
                                                              SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
@@ -113,7 +113,7 @@ static constexpr unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS{SCRIPT_VERIFY_P2SH |
  * the additional (non-mandatory) rules here, to improve forwards and
  * backwards compatibility.
  */
-static constexpr unsigned int STANDARD_SCRIPT_VERIFY_FLAGS{MANDATORY_SCRIPT_VERIFY_FLAGS |
+static constexpr script_verify_flags STANDARD_SCRIPT_VERIFY_FLAGS{MANDATORY_SCRIPT_VERIFY_FLAGS |
                                                              SCRIPT_VERIFY_STRICTENC |
                                                              SCRIPT_VERIFY_MINIMALDATA |
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
@@ -134,7 +134,7 @@ static constexpr unsigned int STANDARD_SCRIPT_VERIFY_FLAGS{MANDATORY_SCRIPT_VERI
 };
 
 /** For convenience, standard but not mandatory verify flags. */
-static constexpr unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS{STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS};
+static constexpr script_verify_flags STANDARD_NOT_MANDATORY_VERIFY_FLAGS{STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS};
 
 /** Used as the flags parameter to sequence and nLocktime checks in non-consensus code. */
 static constexpr unsigned int STANDARD_LOCKTIME_VERIFY_FLAGS{LOCKTIME_VERIFY_SEQUENCE};

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -68,6 +68,8 @@ add_library(bitcoinqt STATIC EXCLUDE_FROM_ALL
   clientmodel.h
   csvmodelwriter.cpp
   csvmodelwriter.h
+  freespacechecker.cpp
+  freespacechecker.h
   guiutil.cpp
   guiutil.h
   initexecutor.cpp

--- a/src/qt/freespacechecker.cpp
+++ b/src/qt/freespacechecker.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2011-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/freespacechecker.h>
+
+#include <qt/guiutil.h>
+#include <qt/intro.h>
+#include <util/fs.h>
+
+#include <QDir>
+#include <QString>
+
+#include <cstdint>
+
+FreespaceChecker::FreespaceChecker(Intro *_intro)
+{
+    this->intro = _intro;
+}
+
+void FreespaceChecker::check()
+{
+    QString dataDirStr = intro->getPathToCheck();
+    fs::path dataDir = GUIUtil::QStringToPath(dataDirStr);
+    uint64_t freeBytesAvailable = 0;
+    int replyStatus = ST_OK;
+    QString replyMessage = tr("A new data directory will be created.");
+
+    /* Find first parent that exists, so that fs::space does not fail */
+    fs::path parentDir = dataDir;
+    fs::path parentDirOld = fs::path();
+    while(parentDir.has_parent_path() && !fs::exists(parentDir))
+    {
+        parentDir = parentDir.parent_path();
+
+        /* Check if we make any progress, break if not to prevent an infinite loop here */
+        if (parentDirOld == parentDir)
+            break;
+
+        parentDirOld = parentDir;
+    }
+
+    try {
+        freeBytesAvailable = fs::space(parentDir).available;
+        if(fs::exists(dataDir))
+        {
+            if(fs::is_directory(dataDir))
+            {
+                QString separator = "<code>" + QDir::toNativeSeparators("/") + tr("name") + "</code>";
+                replyStatus = ST_OK;
+                replyMessage = tr("Directory already exists. Add %1 if you intend to create a new directory here.").arg(separator);
+            } else {
+                replyStatus = ST_ERROR;
+                replyMessage = tr("Path already exists, and is not a directory.");
+            }
+        }
+    } catch (const fs::filesystem_error&)
+    {
+        /* Parent directory does not exist or is not accessible */
+        replyStatus = ST_ERROR;
+        replyMessage = tr("Cannot create data directory here.");
+    }
+    Q_EMIT reply(replyStatus, replyMessage, freeBytesAvailable);
+}

--- a/src/qt/freespacechecker.cpp
+++ b/src/qt/freespacechecker.cpp
@@ -5,18 +5,12 @@
 #include <qt/freespacechecker.h>
 
 #include <qt/guiutil.h>
-#include <qt/intro.h>
 #include <util/fs.h>
 
 #include <QDir>
 #include <QString>
 
 #include <cstdint>
-
-FreespaceChecker::FreespaceChecker(Intro *_intro)
-{
-    this->intro = _intro;
-}
 
 void FreespaceChecker::check()
 {

--- a/src/qt/freespacechecker.h
+++ b/src/qt/freespacechecker.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2011-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_FREESPACECHECKER_H
+#define BITCOIN_QT_FREESPACECHECKER_H
+
+#include <QObject>
+#include <QString>
+#include <QtGlobal>
+
+class Intro;
+
+/* Check free space asynchronously to prevent hanging the UI thread.
+
+   Up to one request to check a path is in flight to this thread; when the check()
+   function runs, the current path is requested from the associated Intro object.
+   The reply is sent back through a signal.
+
+   This ensures that no queue of checking requests is built up while the user is
+   still entering the path, and that always the most recently entered path is checked as
+   soon as the thread becomes available.
+*/
+class FreespaceChecker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit FreespaceChecker(Intro *intro);
+
+    enum Status {
+        ST_OK,
+        ST_ERROR
+    };
+
+public Q_SLOTS:
+    void check();
+
+Q_SIGNALS:
+    void reply(int status, const QString &message, quint64 available);
+
+private:
+    Intro *intro;
+};
+
+#endif // BITCOIN_QT_FREESPACECHECKER_H

--- a/src/qt/freespacechecker.h
+++ b/src/qt/freespacechecker.h
@@ -9,8 +9,6 @@
 #include <QString>
 #include <QtGlobal>
 
-class Intro;
-
 /* Check free space asynchronously to prevent hanging the UI thread.
 
    Up to one request to check a path is in flight to this thread; when the check()
@@ -26,7 +24,13 @@ class FreespaceChecker : public QObject
     Q_OBJECT
 
 public:
-    explicit FreespaceChecker(Intro *intro);
+    class PathQuery
+    {
+    public:
+        virtual QString getPathToCheck() = 0;
+    };
+
+    explicit FreespaceChecker(PathQuery* intro) : intro{intro} {}
 
     enum Status {
         ST_OK,
@@ -40,7 +44,7 @@ Q_SIGNALS:
     void reply(int status, const QString &message, quint64 available);
 
 private:
-    Intro *intro;
+    PathQuery* intro;
 };
 
 #endif // BITCOIN_QT_FREESPACECHECKER_H

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,6 +10,7 @@
 #include <util/chaintype.h>
 #include <util/fs.h>
 
+#include <qt/freespacechecker.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
@@ -24,90 +25,6 @@
 #include <QMessageBox>
 
 #include <cmath>
-
-/* Check free space asynchronously to prevent hanging the UI thread.
-
-   Up to one request to check a path is in flight to this thread; when the check()
-   function runs, the current path is requested from the associated Intro object.
-   The reply is sent back through a signal.
-
-   This ensures that no queue of checking requests is built up while the user is
-   still entering the path, and that always the most recently entered path is checked as
-   soon as the thread becomes available.
-*/
-class FreespaceChecker : public QObject
-{
-    Q_OBJECT
-
-public:
-    explicit FreespaceChecker(Intro *intro);
-
-    enum Status {
-        ST_OK,
-        ST_ERROR
-    };
-
-public Q_SLOTS:
-    void check();
-
-Q_SIGNALS:
-    void reply(int status, const QString &message, quint64 available);
-
-private:
-    Intro *intro;
-};
-
-#include <qt/intro.moc>
-
-FreespaceChecker::FreespaceChecker(Intro *_intro)
-{
-    this->intro = _intro;
-}
-
-void FreespaceChecker::check()
-{
-    QString dataDirStr = intro->getPathToCheck();
-    fs::path dataDir = GUIUtil::QStringToPath(dataDirStr);
-    uint64_t freeBytesAvailable = 0;
-    int replyStatus = ST_OK;
-    QString replyMessage = tr("A new data directory will be created.");
-
-    /* Find first parent that exists, so that fs::space does not fail */
-    fs::path parentDir = dataDir;
-    fs::path parentDirOld = fs::path();
-    while(parentDir.has_parent_path() && !fs::exists(parentDir))
-    {
-        parentDir = parentDir.parent_path();
-
-        /* Check if we make any progress, break if not to prevent an infinite loop here */
-        if (parentDirOld == parentDir)
-            break;
-
-        parentDirOld = parentDir;
-    }
-
-    try {
-        freeBytesAvailable = fs::space(parentDir).available;
-        if(fs::exists(dataDir))
-        {
-            if(fs::is_directory(dataDir))
-            {
-                QString separator = "<code>" + QDir::toNativeSeparators("/") + tr("name") + "</code>";
-                replyStatus = ST_OK;
-                replyMessage = tr("Directory already exists. Add %1 if you intend to create a new directory here.").arg(separator);
-            } else {
-                replyStatus = ST_ERROR;
-                replyMessage = tr("Path already exists, and is not a directory.");
-            }
-        }
-    } catch (const fs::filesystem_error&)
-    {
-        /* Parent directory does not exist or is not accessible */
-        replyStatus = ST_ERROR;
-        replyMessage = tr("Cannot create data directory here.");
-    }
-    Q_EMIT reply(replyStatus, replyMessage, freeBytesAvailable);
-}
 
 namespace {
 //! Return pruning size that will be used if automatic pruning is enabled.

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_QT_INTRO_H
 #define BITCOIN_QT_INTRO_H
 
+#include <qt/freespacechecker.h>
+
 #include <QDialog>
 #include <QMutex>
 #include <QThread>
 
 static const bool DEFAULT_CHOOSE_DATADIR = false;
-
-class FreespaceChecker;
 
 namespace interfaces {
     class Node;
@@ -25,7 +25,7 @@ namespace Ui {
   Allows the user to choose a data directory,
   in which the wallet and block chain will be stored.
  */
-class Intro : public QDialog
+class Intro : public QDialog, public FreespaceChecker::PathQuery
 {
     Q_OBJECT
 
@@ -78,7 +78,7 @@ private:
 
     void startThread();
     void checkPath(const QString &dataDir);
-    QString getPathToCheck();
+    QString getPathToCheck() override;
     void UpdatePruneLabels(bool prune_checked);
     void UpdateFreeSpaceLabel();
 

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2021 The Bitcoin Core developers
+// Copyright (c) 2011-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -12,6 +12,7 @@
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/script_error.h> // IWYU pragma: export
+#include <script/verify_flags.h> // IWYU pragma: export
 #include <span.h>
 #include <uint256.h>
 
@@ -155,7 +156,7 @@ enum : uint32_t {
     SCRIPT_VERIFY_END_MARKER
 };
 
-bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);
+bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, script_verify_flags flags, ScriptError* serror);
 
 struct PrecomputedTransactionData
 {
@@ -385,15 +386,15 @@ uint256 ComputeTapbranchHash(Span<const unsigned char> a, Span<const unsigned ch
  *  Requires control block to have valid length (33 + k*32, with k in {0,1,..,128}). */
 uint256 ComputeTaprootMerkleRoot(Span<const unsigned char> control, const uint256& tapleaf_hash);
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* error = nullptr);
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
-bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror = nullptr);
+bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, script_verify_flags flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* error = nullptr);
+bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, script_verify_flags flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
+bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, script_verify_flags flags, const BaseSignatureChecker& checker, ScriptError* serror = nullptr);
 
-size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags);
+size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, script_verify_flags flags);
 
 int FindAndDelete(CScript& script, const CScript& b);
 
 bool CastToBool(const std::vector<unsigned char>& vch);
-std::optional<bool> CheckTapscriptOpSuccess(const CScript& exec_script, unsigned int flags, ScriptError* serror);
+std::optional<bool> CheckTapscriptOpSuccess(const CScript& exec_script, script_verify_flags flags, ScriptError* serror);
 
 #endif // BITCOIN_SCRIPT_INTERPRETER_H

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -16,6 +16,7 @@
 #include <span.h>
 #include <uint256.h>
 
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -45,9 +46,10 @@ enum
  *  All flags are intended to be soft forks: the set of acceptable scripts under
  *  flags (A | B) is a subset of the acceptable scripts under flag (A).
  */
-enum : uint32_t {
-    SCRIPT_VERIFY_NONE      = 0,
 
+static constexpr script_verify_flags SCRIPT_VERIFY_NONE{0};
+
+enum class script_verify_flag_name : uint32_t {
     // Evaluate P2SH subscripts (BIP16).
     SCRIPT_VERIFY_P2SH      = (1U << 0),
 
@@ -155,6 +157,13 @@ enum : uint32_t {
     //
     SCRIPT_VERIFY_END_MARKER
 };
+using enum script_verify_flag_name;
+
+// assert there is still a spare bit
+static_assert(static_cast<script_verify_flags::value_type>(SCRIPT_VERIFY_END_MARKER) < (1u << 31));
+
+static constexpr script_verify_flags::value_type MAX_SCRIPT_VERIFY_FLAGS = ((static_cast<script_verify_flags::value_type>(SCRIPT_VERIFY_END_MARKER) - 1) << 1) - 1;
+static constexpr int MAX_SCRIPT_VERIFY_FLAGS_BITS = std::bit_width(MAX_SCRIPT_VERIFY_FLAGS);
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, script_verify_flags flags, ScriptError* serror);
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -49,7 +49,7 @@ enum
 
 static constexpr script_verify_flags SCRIPT_VERIFY_NONE{0};
 
-enum class script_verify_flag_name : uint32_t {
+enum class script_verify_flag_name : uint64_t {
     // Evaluate P2SH subscripts (BIP16).
     SCRIPT_VERIFY_P2SH      = (1U << 0),
 
@@ -160,7 +160,7 @@ enum class script_verify_flag_name : uint32_t {
 using enum script_verify_flag_name;
 
 // assert there is still a spare bit
-static_assert(static_cast<script_verify_flags::value_type>(SCRIPT_VERIFY_END_MARKER) < (1u << 31));
+static_assert(static_cast<script_verify_flags::value_type>(SCRIPT_VERIFY_END_MARKER) < (uint64_t{1} << 63));
 
 static constexpr script_verify_flags::value_type MAX_SCRIPT_VERIFY_FLAGS = ((static_cast<script_verify_flags::value_type>(SCRIPT_VERIFY_END_MARKER) - 1) << 1) - 1;
 static constexpr int MAX_SCRIPT_VERIFY_FLAGS_BITS = std::bit_width(MAX_SCRIPT_VERIFY_FLAGS);

--- a/src/script/verify_flags.h
+++ b/src/script/verify_flags.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_VERIFY_FLAGS_H
+#define BITCOIN_SCRIPT_VERIFY_FLAGS_H
+
+#include <cstdint>
+
+using script_verify_flags = uint32_t;
+
+#endif // BITCOIN_SCRIPT_VERIFY_FLAGS_H

--- a/src/script/verify_flags.h
+++ b/src/script/verify_flags.h
@@ -6,8 +6,66 @@
 #ifndef BITCOIN_SCRIPT_VERIFY_FLAGS_H
 #define BITCOIN_SCRIPT_VERIFY_FLAGS_H
 
+#include <compare>
 #include <cstdint>
 
-using script_verify_flags = uint32_t;
+enum class script_verify_flag_name : uint32_t;
+
+class script_verify_flags
+{
+public:
+    using value_type = uint32_t;
+
+    consteval script_verify_flags() = default;
+
+    // also allow construction with hard-coded 0 (but not other integers)
+    consteval explicit(false) script_verify_flags(value_type f) : m_value{f} { if (f != 0) throw 0; }
+
+    // implicit construction from a hard-coded SCRIPT_VERIFY_* constant is also okay
+    constexpr explicit(false) script_verify_flags(script_verify_flag_name f) : m_value{static_cast<value_type>(f)} { }
+
+    // rule of 5
+    constexpr script_verify_flags(const script_verify_flags&) = default;
+    constexpr script_verify_flags(script_verify_flags&&) = default;
+    constexpr script_verify_flags& operator=(const script_verify_flags&) = default;
+    constexpr script_verify_flags& operator=(script_verify_flags&&) = default;
+    constexpr ~script_verify_flags() = default;
+
+    // integer conversion needs to be very explicit
+    static constexpr script_verify_flags from_int(value_type f) { script_verify_flags r; r.m_value = f; return r; }
+    constexpr value_type as_int() const { return m_value; }
+
+    // bitwise operations
+    constexpr script_verify_flags operator~() const { return from_int(~m_value); }
+    friend constexpr script_verify_flags operator|(script_verify_flags a, script_verify_flags b) { return from_int(a.m_value | b.m_value); }
+    friend constexpr script_verify_flags operator&(script_verify_flags a, script_verify_flags b) { return from_int(a.m_value & b.m_value); }
+
+    // in-place bitwise operations
+    constexpr script_verify_flags& operator|=(script_verify_flags vf) { m_value |= vf.m_value; return *this; }
+    constexpr script_verify_flags& operator&=(script_verify_flags vf) { m_value &= vf.m_value; return *this; }
+
+    // tests
+    constexpr explicit operator bool() const { return m_value != 0; }
+    constexpr bool operator==(script_verify_flags other) const { return m_value == other.m_value; }
+
+    /** Compare two script_verify_flags. <, >, <=, and >= are auto-generated from this. */
+    friend constexpr std::strong_ordering operator<=>(const script_verify_flags& a, const script_verify_flags& b) noexcept
+    {
+        return a.m_value <=> b.m_value;
+    }
+
+private:
+    value_type m_value{0}; // default value is SCRIPT_VERIFY_NONE
+};
+
+inline constexpr script_verify_flags operator~(script_verify_flag_name f)
+{
+    return ~script_verify_flags{f};
+}
+
+inline constexpr script_verify_flags operator|(script_verify_flag_name f1, script_verify_flag_name f2)
+{
+    return script_verify_flags{f1} | f2;
+}
 
 #endif // BITCOIN_SCRIPT_VERIFY_FLAGS_H

--- a/src/script/verify_flags.h
+++ b/src/script/verify_flags.h
@@ -9,12 +9,12 @@
 #include <compare>
 #include <cstdint>
 
-enum class script_verify_flag_name : uint32_t;
+enum class script_verify_flag_name : uint64_t;
 
 class script_verify_flags
 {
 public:
-    using value_type = uint32_t;
+    using value_type = uint64_t;
 
     consteval script_verify_flags() = default;
 

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -26,7 +26,7 @@
 
 static constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2};
 
-static constexpr unsigned int BLOCK_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_NULLDUMMY;
+static constexpr script_verify_flags BLOCK_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_NULLDUMMY;
 
 static bool FetchAndClearCommitmentSection(const Span<const uint8_t> header, CScript& witness_commitment, std::vector<uint8_t>& result)
 {

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -275,7 +275,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                     // consensus/tx_verify.cpp:130: unsigned int GetP2SHSigOpCount(const CTransaction &, const CCoinsViewCache &): Assertion `!coin.IsSpent()' failed.
                     return;
                 }
-                const auto flags{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+                const auto flags = script_verify_flags::from_int(fuzzed_data_provider.ConsumeIntegral<script_verify_flags::value_type>());
                 if (!transaction.vin.empty() && (flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
                     // Avoid:
                     // script/interpreter.cpp:1705: size_t CountWitnessSigOps(const CScript &, const CScript &, const CScriptWitness *, unsigned int): Assertion `(flags & SCRIPT_VERIFY_P2SH) != 0' failed.

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -12,7 +12,7 @@
 FUZZ_TARGET(eval_script)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const unsigned int flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const script_verify_flags flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
     const std::vector<uint8_t> script_bytes = [&] {
         if (fuzzed_data_provider.remaining_bytes() != 0) {
             return fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>();

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -12,7 +12,7 @@
 FUZZ_TARGET(eval_script)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const script_verify_flags flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const auto flags = script_verify_flags::from_int(fuzzed_data_provider.ConsumeIntegral<script_verify_flags::value_type>());
     const std::vector<uint8_t> script_bytes = [&] {
         if (fuzzed_data_provider.remaining_bytes() != 0) {
             return fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>();

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -120,7 +120,7 @@ FUZZ_TARGET(script, .init = initialize_script)
         }
         const std::vector<std::string> random_string_vector = ConsumeRandomLengthStringVector(fuzzed_data_provider);
         const uint32_t u32{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
-        const uint32_t flags{u32 | SCRIPT_VERIFY_P2SH};
+        const script_verify_flags flags{u32 | SCRIPT_VERIFY_P2SH};
         {
             CScriptWitness wit;
             for (const auto& s : random_string_vector) {

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -119,8 +119,8 @@ FUZZ_TARGET(script, .init = initialize_script)
             (void)FindAndDelete(script_mut, *other_script);
         }
         const std::vector<std::string> random_string_vector = ConsumeRandomLengthStringVector(fuzzed_data_provider);
-        const uint32_t u32{fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
-        const script_verify_flags flags{u32 | SCRIPT_VERIFY_P2SH};
+        const auto flags_rand{fuzzed_data_provider.ConsumeIntegral<script_verify_flags::value_type>()};
+        const auto flags = script_verify_flags::from_int(flags_rand) | SCRIPT_VERIFY_P2SH;
         {
             CScriptWitness wit;
             for (const auto& s : random_string_vector) {

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -90,7 +90,7 @@ CScriptWitness ScriptWitnessFromJSON(const UniValue& univalue)
     return scriptwitness;
 }
 
-const std::map<std::string, uint32_t> FLAG_NAMES = {
+const std::map<std::string, script_verify_flag_name> FLAG_NAMES = {
     {std::string("P2SH"), SCRIPT_VERIFY_P2SH},
     {std::string("DERSIG"), SCRIPT_VERIFY_DERSIG},
     {std::string("NULLDUMMY"), SCRIPT_VERIFY_NULLDUMMY},

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -90,23 +90,23 @@ CScriptWitness ScriptWitnessFromJSON(const UniValue& univalue)
     return scriptwitness;
 }
 
-const std::map<std::string, unsigned int> FLAG_NAMES = {
-    {std::string("P2SH"), (unsigned int)SCRIPT_VERIFY_P2SH},
-    {std::string("DERSIG"), (unsigned int)SCRIPT_VERIFY_DERSIG},
-    {std::string("NULLDUMMY"), (unsigned int)SCRIPT_VERIFY_NULLDUMMY},
-    {std::string("CHECKLOCKTIMEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY},
-    {std::string("CHECKSEQUENCEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKSEQUENCEVERIFY},
-    {std::string("WITNESS"), (unsigned int)SCRIPT_VERIFY_WITNESS},
-    {std::string("TAPROOT"), (unsigned int)SCRIPT_VERIFY_TAPROOT},
-    {std::string("ANYPREVOUT"), (unsigned int)SCRIPT_VERIFY_ANYPREVOUT},
+const std::map<std::string, uint32_t> FLAG_NAMES = {
+    {std::string("P2SH"), SCRIPT_VERIFY_P2SH},
+    {std::string("DERSIG"), SCRIPT_VERIFY_DERSIG},
+    {std::string("NULLDUMMY"), SCRIPT_VERIFY_NULLDUMMY},
+    {std::string("CHECKLOCKTIMEVERIFY"), SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY},
+    {std::string("CHECKSEQUENCEVERIFY"), SCRIPT_VERIFY_CHECKSEQUENCEVERIFY},
+    {std::string("WITNESS"), SCRIPT_VERIFY_WITNESS},
+    {std::string("TAPROOT"), SCRIPT_VERIFY_TAPROOT},
+    {std::string("ANYPREVOUT"), SCRIPT_VERIFY_ANYPREVOUT},
 };
 
-std::vector<unsigned int> AllFlags()
+std::vector<script_verify_flags> AllFlags()
 {
-    std::vector<unsigned int> ret;
+    std::vector<script_verify_flags> ret;
 
     for (unsigned int i = 0; i < 128; ++i) {
-        unsigned int flag = 0;
+        script_verify_flags flag = 0;
         if (i & 1) flag |= SCRIPT_VERIFY_P2SH;
         if (i & 2) flag |= SCRIPT_VERIFY_DERSIG;
         if (i & 4) flag |= SCRIPT_VERIFY_NULLDUMMY;
@@ -126,13 +126,13 @@ std::vector<unsigned int> AllFlags()
     return ret;
 }
 
-const std::vector<unsigned int> ALL_FLAGS = AllFlags();
+const std::vector<script_verify_flags> ALL_FLAGS = AllFlags();
 
-unsigned int ParseScriptFlags(const std::string& str)
+script_verify_flags ParseScriptFlags(const std::string& str)
 {
     if (str.empty()) return 0;
 
-    unsigned int flags = 0;
+    script_verify_flags flags = 0;
     std::vector<std::string> words = SplitString(str, ',');
 
     for (const std::string& word : words) {
@@ -154,7 +154,7 @@ void Test(const std::string& str)
     if (prevouts.size() != tx.vin.size()) throw std::runtime_error("Incorrect number of prevouts");
     size_t idx = test["index"].getInt<int64_t>();
     if (idx >= tx.vin.size()) throw std::runtime_error("Invalid index");
-    unsigned int test_flags = ParseScriptFlags(test["flags"].get_str());
+    script_verify_flags test_flags = ParseScriptFlags(test["flags"].get_str());
     bool final = test.exists("final") && test["final"].get_bool();
 
     if (test.exists("success")) {

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -15,6 +15,14 @@
 #include <utility>
 #include <vector>
 
+static DataStream& operator>>(DataStream& ds, script_verify_flags& f)
+{
+    script_verify_flags::value_type n{0};
+    ds >> n;
+    f = script_verify_flags::from_int(n);
+    return ds;
+}
+
 FUZZ_TARGET(script_flags)
 {
     if (buffer.size() > 100'000) return;

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -22,12 +22,12 @@ FUZZ_TARGET(script_flags)
     try {
         const CTransaction tx(deserialize, TX_WITH_WITNESS, ds);
 
-        unsigned int verify_flags;
+        script_verify_flags verify_flags;
         ds >> verify_flags;
 
         if (!IsValidFlagCombination(verify_flags)) return;
 
-        unsigned int fuzzed_flags;
+        script_verify_flags fuzzed_flags;
         ds >> fuzzed_flags;
 
         std::vector<CTxOut> spent_outputs;

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -51,7 +51,7 @@ public:
 FUZZ_TARGET(signature_checker)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const script_verify_flags flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const auto flags = script_verify_flags::from_int(fuzzed_data_provider.ConsumeIntegral<script_verify_flags::value_type>());
     const SigVersion sig_version = fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0});
     const auto script_1{ConsumeScript(fuzzed_data_provider)};
     const auto script_2{ConsumeScript(fuzzed_data_provider)};

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -51,7 +51,7 @@ public:
 FUZZ_TARGET(signature_checker)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const unsigned int flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const script_verify_flags flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
     const SigVersion sig_version = fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0});
     const auto script_1{ConsumeScript(fuzzed_data_provider)};
     const auto script_2{ConsumeScript(fuzzed_data_provider)};

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -38,7 +38,7 @@ sign_multisig(const CScript& scriptPubKey, const std::vector<CKey>& keys, const 
 
 BOOST_AUTO_TEST_CASE(multisig_verify)
 {
-    unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
+    script_verify_flags flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 
     ScriptError err;
     CKey key[4];

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1763,9 +1763,9 @@ BOOST_AUTO_TEST_CASE(formatscriptflags)
 {
     // quick check that FormatScriptFlags reports any unknown/unexpected bits
     BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH), "P2SH");
-    BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH | script_verify_flags::from_int(1u<<31)), "P2SH,0x80000000");
-    BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | script_verify_flags::from_int(1u<<31)), "TAPROOT,0x80000000");
-    BOOST_CHECK_EQUAL(FormatScriptFlags(script_verify_flags::from_int(1u<<31)), "0x80000000");
+    BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH | script_verify_flags::from_int(uint64_t{1}<<63)), "P2SH,0x8000000000000000");
+    BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | script_verify_flags::from_int(uint64_t{1}<<63)), "TAPROOT,0x8000000000000000");
+    BOOST_CHECK_EQUAL(FormatScriptFlags(script_verify_flags::from_int(uint64_t{1}<<63)), "0x8000000000000000");
 }
 
 void DoTapscriptTest(ScriptTest& test, std::vector<unsigned char> witVerifyScript, std::vector<std::vector<unsigned char>> witData, const std::string& message, int scriptError)

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -40,9 +40,9 @@
 
 using namespace util::hex_literals;
 
-static const unsigned int gFlags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
+static const script_verify_flags gFlags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 
-unsigned int ParseScriptFlags(std::string strFlags);
+script_verify_flags ParseScriptFlags(std::string strFlags);
 
 struct ScriptErrorDesc
 {
@@ -97,7 +97,7 @@ static ScriptErrorDesc script_errors[]={
     INQ_SCRIPTERR_TEST_NAMES
 };
 
-std::string FormatScriptFlags(uint32_t flags)
+static std::string FormatScriptFlags(script_verify_flags flags)
 {
     return util::Join(GetScriptFlagNames(flags), ",");
 }
@@ -121,7 +121,7 @@ static ScriptError_t ParseScriptError(const std::string& name)
 }
 
 struct ScriptTest : BasicTestingSetup {
-void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScriptWitness& scriptWitness, uint32_t flags, const std::string& message, int scriptError, CAmount nValue = 0)
+void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScriptWitness& scriptWitness, script_verify_flags flags, const std::string& message, int scriptError, CAmount nValue = 0)
 {
     bool expect = (scriptError == SCRIPT_ERR_OK);
     if (flags & SCRIPT_VERIFY_CLEANSTACK) {
@@ -241,7 +241,7 @@ private:
     bool havePush{false};
     std::vector<unsigned char> push;
     std::string comment;
-    uint32_t flags;
+    script_verify_flags flags;
     int scriptError{SCRIPT_ERR_OK};
     CAmount nValue;
 
@@ -261,7 +261,7 @@ private:
     }
 
 public:
-    TestBuilder(const CScript& script_, const std::string& comment_, uint32_t flags_, bool P2SH = false, WitnessMode wm = WitnessMode::NONE, int witnessversion = 0, CAmount nValue_ = 0) : script(script_), comment(comment_), flags(flags_), nValue(nValue_)
+    TestBuilder(const CScript& script_, const std::string& comment_, script_verify_flags flags_, bool P2SH = false, WitnessMode wm = WitnessMode::NONE, int witnessversion = 0, CAmount nValue_ = 0) : script(script_), comment(comment_), flags(flags_), nValue(nValue_)
     {
         CScript scriptPubKey = script;
         if (wm == WitnessMode::PKH) {
@@ -974,7 +974,7 @@ BOOST_AUTO_TEST_CASE(script_json_test)
         } else {
             scriptPubKey = ParseScript(scriptPubKeyString);
         }
-        unsigned int scriptflags = ParseScriptFlags(test[pos++].get_str());
+        script_verify_flags scriptflags = ParseScriptFlags(test[pos++].get_str());
         int scriptError = ParseScriptError(test[pos++].get_str());
 
         DoTest(scriptPubKey, scriptSig, witness, scriptflags, strTest, scriptError, nValue);
@@ -1560,12 +1560,12 @@ static CScriptWitness ScriptWitnessFromJSON(const UniValue& univalue)
     return scriptwitness;
 }
 
-static std::vector<unsigned int> AllConsensusFlags()
+static std::vector<script_verify_flags> AllConsensusFlags()
 {
-    std::vector<unsigned int> ret;
+    std::vector<script_verify_flags> ret;
 
     for (unsigned int i = 0; i < 256; ++i) {
-        unsigned int flag = 0;
+        script_verify_flags flag = 0;
         if (i & 1) flag |= SCRIPT_VERIFY_P2SH;
         if (i & 2) flag |= SCRIPT_VERIFY_DERSIG;
         if (i & 4) flag |= SCRIPT_VERIFY_NULLDUMMY;
@@ -1589,7 +1589,7 @@ static std::vector<unsigned int> AllConsensusFlags()
 }
 
 /** Precomputed list of all valid combinations of consensus-relevant script validation flags. */
-static const std::vector<unsigned int> ALL_CONSENSUS_FLAGS = AllConsensusFlags();
+static const std::vector<script_verify_flags> ALL_CONSENSUS_FLAGS = AllConsensusFlags();
 
 static void AssetTest(const UniValue& test, SignatureCache& signature_cache)
 {
@@ -1599,7 +1599,7 @@ static void AssetTest(const UniValue& test, SignatureCache& signature_cache)
     const std::vector<CTxOut> prevouts = TxOutsFromJSON(test["prevouts"]);
     BOOST_CHECK(prevouts.size() == mtx.vin.size());
     size_t idx = test["index"].getInt<int64_t>();
-    uint32_t test_flags{ParseScriptFlags(test["flags"].get_str())};
+    script_verify_flags test_flags{ParseScriptFlags(test["flags"].get_str())};
     bool fin = test.exists("final") && test["final"].get_bool();
 
     if (test.exists("success")) {
@@ -1782,7 +1782,7 @@ void DoTapscriptTest(ScriptTest& test, std::vector<unsigned char> witVerifyScrip
     auto controlblock = *(builder.GetSpendData().scripts[{witVerifyScript, TAPROOT_LEAF_TAPSCRIPT}].begin());
     witness.stack.push_back(controlblock);
 
-    uint32_t flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_OP_CAT;
+    script_verify_flags flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_OP_CAT;
     CScript scriptPubKey = CScript() << OP_1 << ToByteVector(builder.GetOutput());
     CScript scriptSig = CScript(); // Script sig is always size 0 and empty in tapscript
     test.DoTest(scriptPubKey, scriptSig, witness, flags, message, scriptError, /*nValue=*/1);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
  * Verifies script execution of the zeroth scriptPubKey of tx output and
  * zeroth scriptSig and witness of tx input.
  */
-static ScriptError VerifyWithFlag(const CTransaction& output, const CMutableTransaction& input, uint32_t flags)
+static ScriptError VerifyWithFlag(const CTransaction& output, const CMutableTransaction& input, script_verify_flags flags)
 {
     ScriptError error;
     CTransaction inputi(input);
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
     CKey key = GenerateRandomKey();
     CPubKey pubkey = key.GetPubKey();
     // Default flags
-    const uint32_t flags{SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH};
+    const script_verify_flags flags{SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH};
 
     // Multisig script (legacy counting)
     {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -52,9 +52,9 @@ static bool g_bare_multi{DEFAULT_PERMIT_BAREMULTISIG};
 
 static const std::map<std::string, unsigned int>& mapFlagNames = g_verify_flag_names;
 
-unsigned int ParseScriptFlags(std::string strFlags)
+script_verify_flags ParseScriptFlags(std::string strFlags)
 {
-    unsigned int flags = SCRIPT_VERIFY_NONE;
+    script_verify_flags flags = SCRIPT_VERIFY_NONE;
     if (strFlags.empty() || strFlags == "NONE") return flags;
 
     std::vector<std::string> words = SplitString(strFlags, ',');
@@ -72,7 +72,7 @@ unsigned int ParseScriptFlags(std::string strFlags)
 // Check that all flags in STANDARD_SCRIPT_VERIFY_FLAGS are present in mapFlagNames.
 bool CheckMapFlagNames()
 {
-    unsigned int standard_flags_missing{STANDARD_SCRIPT_VERIFY_FLAGS};
+    script_verify_flags standard_flags_missing{STANDARD_SCRIPT_VERIFY_FLAGS};
     for (const auto& pair : mapFlagNames) {
         standard_flags_missing &= ~(pair.second);
     }
@@ -83,7 +83,7 @@ bool CheckMapFlagNames()
 * Check that the input scripts of a transaction are valid/invalid as expected.
 */
 bool CheckTxScripts(const CTransaction& tx, const std::map<COutPoint, CScript>& map_prevout_scriptPubKeys,
-    const std::map<COutPoint, int64_t>& map_prevout_values, unsigned int flags,
+    const std::map<COutPoint, int64_t>& map_prevout_values, script_verify_flags flags,
     const PrecomputedTransactionData& txdata, const std::string& strTest, bool expect_valid)
 {
     bool tx_valid = true;
@@ -117,18 +117,18 @@ bool CheckTxScripts(const CTransaction& tx, const std::map<COutPoint, CScript>& 
  * CLEANSTACK must be used WITNESS and P2SH
  */
 
-unsigned int TrimFlags(unsigned int flags)
+script_verify_flags TrimFlags(script_verify_flags flags)
 {
     // WITNESS requires P2SH
-    if (!(flags & SCRIPT_VERIFY_P2SH)) flags &= ~(unsigned int)SCRIPT_VERIFY_WITNESS;
+    if (!(flags & SCRIPT_VERIFY_P2SH)) flags &= ~SCRIPT_VERIFY_WITNESS;
 
     // CLEANSTACK requires WITNESS (and transitively CLEANSTACK requires P2SH)
-    if (!(flags & SCRIPT_VERIFY_WITNESS)) flags &= ~(unsigned int)SCRIPT_VERIFY_CLEANSTACK;
+    if (!(flags & SCRIPT_VERIFY_WITNESS)) flags &= ~SCRIPT_VERIFY_CLEANSTACK;
     Assert(IsValidFlagCombination(flags));
     return flags;
 }
 
-unsigned int FillFlags(unsigned int flags)
+script_verify_flags FillFlags(script_verify_flags flags)
 {
     // CLEANSTACK implies WITNESS
     if (flags & SCRIPT_VERIFY_CLEANSTACK) flags |= SCRIPT_VERIFY_WITNESS;
@@ -143,11 +143,11 @@ unsigned int FillFlags(unsigned int flags)
 // that are valid and without duplicates. For example: if flags=1111 and the 4 possible flags are
 // 0001, 0010, 0100, and 1000, this should return the set {0111, 1011, 1101, 1110}.
 // Assumes that mapFlagNames contains all script verify flags.
-std::set<unsigned int> ExcludeIndividualFlags(unsigned int flags)
+std::set<script_verify_flags> ExcludeIndividualFlags(script_verify_flags flags)
 {
-    std::set<unsigned int> flags_combos;
+    std::set<script_verify_flags> flags_combos;
     for (const auto& pair : mapFlagNames) {
-        const unsigned int flags_excluding_one = TrimFlags(flags & ~(pair.second));
+        script_verify_flags flags_excluding_one = TrimFlags(flags & ~(pair.second));
         if (flags != flags_excluding_one) {
             flags_combos.insert(flags_excluding_one);
         }
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             BOOST_CHECK(state.IsValid());
 
             PrecomputedTransactionData txdata(tx);
-            unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
+            script_verify_flags verify_flags = ParseScriptFlags(test[2].get_str());
 
             // Check that the test gives a valid combination of flags (otherwise VerifyScript will throw). Don't edit the flags.
             if (~verify_flags != FillFlags(~verify_flags)) {
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             // Backwards compatibility of script verification flags: Removing any flag(s) should not invalidate a valid transaction
             for (const auto& [name, flag] : mapFlagNames) {
                 // Removing individual flags
-                unsigned int flags = TrimFlags(~(verify_flags | flag));
+                script_verify_flags flags = TrimFlags(~(verify_flags | flag));
                 if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, flags, txdata, strTest, /*expect_valid=*/true)) {
                     BOOST_ERROR("Tx unexpectedly failed with flag " << name << " unset: " << strTest);
                 }
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             }
 
             PrecomputedTransactionData txdata(tx);
-            unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
+            script_verify_flags verify_flags = ParseScriptFlags(test[2].get_str());
 
             // Check that the test gives a valid combination of flags (otherwise VerifyScript will throw). Don't edit the flags.
             if (verify_flags != FillFlags(verify_flags)) {
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
 
             // Backwards compatibility of script verification flags: Adding any flag(s) should not validate an invalid transaction
             for (const auto& [name, flag] : mapFlagNames) {
-                unsigned int flags = FillFlags(verify_flags | flag);
+                script_verify_flags flags = FillFlags(verify_flags | flag);
                 // Adding individual flags
                 if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, flags, txdata, strTest, /*expect_valid=*/false)) {
                     BOOST_ERROR("Tx unexpectedly passed with flag " << name << " set: " << strTest);
@@ -453,7 +453,7 @@ static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const 
     assert(input.vin[0].scriptWitness.stack == inputm.vin[0].scriptWitness.stack);
 }
 
-static void CheckWithFlag(const CTransactionRef& output, const CMutableTransaction& input, uint32_t flags, bool success)
+static void CheckWithFlag(const CTransactionRef& output, const CMutableTransaction& input, script_verify_flags flags, bool success)
 {
     ScriptError error;
     CTransaction inputi(input);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -50,7 +50,7 @@ typedef std::vector<unsigned char> valtype;
 static CFeeRate g_dust{DUST_RELAY_TX_FEE};
 static bool g_bare_multi{DEFAULT_PERMIT_BAREMULTISIG};
 
-static const std::map<std::string, unsigned int>& mapFlagNames = g_verify_flag_names;
+static const std::map<std::string, script_verify_flag_name>& mapFlagNames = g_verify_flag_names;
 
 script_verify_flags ParseScriptFlags(std::string strFlags)
 {
@@ -230,9 +230,9 @@ BOOST_AUTO_TEST_CASE(tx_valid)
                     BOOST_ERROR("Tx unexpectedly failed with flag " << name << " unset: " << strTest);
                 }
                 // Removing random combinations of flags
-                flags = TrimFlags(~(verify_flags | (unsigned int)m_rng.randbits(mapFlagNames.size())));
+                flags = TrimFlags(~(verify_flags | script_verify_flags::from_int(m_rng.randbits(MAX_SCRIPT_VERIFY_FLAGS_BITS))));
                 if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, flags, txdata, strTest, /*expect_valid=*/true)) {
-                    BOOST_ERROR("Tx unexpectedly failed with random flags " << ToString(flags) << ": " << strTest);
+                    BOOST_ERROR("Tx unexpectedly failed with random flags " << ToString(flags.as_int()) << ": " << strTest);
                 }
             }
 
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
                     BOOST_ERROR("Tx unexpectedly passed with flag " << name << " set: " << strTest);
                 }
                 // Adding random combinations of flags
-                flags = FillFlags(verify_flags | (unsigned int)m_rng.randbits(mapFlagNames.size()));
+                flags = FillFlags(verify_flags | script_verify_flags::from_int(m_rng.randbits(MAX_SCRIPT_VERIFY_FLAGS_BITS)));
                 if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, flags, txdata, strTest, /*expect_valid=*/false)) {
                     BOOST_ERROR("Tx unexpectedly passed with random flags " << name << ": " << strTest);
                 }

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -130,7 +130,7 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify
         TxValidationState state;
 
         // Randomly selects flag combinations
-        script_verify_flags test_flags = (uint32_t) insecure_rand.randrange((SCRIPT_VERIFY_END_MARKER - 1) << 1);
+        script_verify_flags test_flags = script_verify_flags::from_int(insecure_rand.randrange(MAX_SCRIPT_VERIFY_FLAGS));
 
         // Filter out incompatible flag choices
         if ((test_flags & SCRIPT_VERIFY_CLEANSTACK)) {

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -21,7 +21,7 @@ struct Dersig100Setup : public TestChain100Setup {
 };
 
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
-                       const CCoinsViewCache& inputs, unsigned int flags, bool cacheSigStore,
+                       const CCoinsViewCache& inputs, script_verify_flags flags, bool cacheSigStore,
                        bool cacheFullScriptStore, PrecomputedTransactionData& txdata,
                        ValidationCache& validation_cache,
                        std::vector<CScriptCheck>* pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -120,7 +120,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
 // should fail.
 // Capture this interaction with the upgraded_nop argument: set it when evaluating
 // any script flag that is implemented as an upgraded NOP code.
-static void ValidateCheckInputsForAllFlags(const CTransaction &tx, uint32_t failing_flags, bool add_to_cache, CCoinsViewCache& active_coins_tip, ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+static void ValidateCheckInputsForAllFlags(const CTransaction &tx, script_verify_flags failing_flags, bool add_to_cache, CCoinsViewCache& active_coins_tip, ValidationCache& validation_cache) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     PrecomputedTransactionData txdata;
 
@@ -130,7 +130,7 @@ static void ValidateCheckInputsForAllFlags(const CTransaction &tx, uint32_t fail
         TxValidationState state;
 
         // Randomly selects flag combinations
-        uint32_t test_flags = (uint32_t) insecure_rand.randrange((SCRIPT_VERIFY_END_MARKER - 1) << 1);
+        script_verify_flags test_flags = (uint32_t) insecure_rand.randrange((SCRIPT_VERIFY_END_MARKER - 1) << 1);
 
         // Filter out incompatible flag choices
         if ((test_flags & SCRIPT_VERIFY_CLEANSTACK)) {

--- a/src/test/util/script.cpp
+++ b/src/test/util/script.cpp
@@ -5,7 +5,7 @@
 #include <script/interpreter.h>
 #include <test/util/script.h>
 
-bool IsValidFlagCombination(unsigned flags)
+bool IsValidFlagCombination(script_verify_flags flags)
 {
     if (flags & SCRIPT_VERIFY_CLEANSTACK && ~flags & (SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS)) return false;
     if (flags & SCRIPT_VERIFY_WITNESS && ~flags & SCRIPT_VERIFY_P2SH) return false;

--- a/src/test/util/script.h
+++ b/src/test/util/script.h
@@ -7,6 +7,7 @@
 
 #include <crypto/sha256.h>
 #include <script/script.h>
+#include <script/verify_flags.h>
 
 static const std::vector<uint8_t> WITNESS_STACK_ELEM_OP_TRUE{uint8_t{OP_TRUE}};
 static const CScript P2WSH_OP_TRUE{
@@ -31,6 +32,6 @@ static const std::vector<std::vector<uint8_t>> P2WSH_EMPTY_TRUE_STACK{{static_ca
 static const std::vector<std::vector<uint8_t>> P2WSH_EMPTY_TWO_STACK{{static_cast<uint8_t>(OP_2)}, {}};
 
 /** Flags that are not forbidden by an assert in script validation */
-bool IsValidFlagCombination(unsigned flags);
+bool IsValidFlagCombination(script_verify_flags flags);
 
 #endif // BITCOIN_TEST_UTIL_SCRIPT_H

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,6 +23,7 @@
 #include <policy/policy.h>
 #include <script/script_error.h>
 #include <script/sigcache.h>
+#include <script/verify_flags.h>
 #include <sync.h>
 #include <txdb.h>
 #include <txmempool.h> // For CTxMemPool::cs
@@ -333,14 +334,14 @@ private:
     CTxOut m_tx_out;
     const CTransaction *ptxTo;
     unsigned int nIn;
-    unsigned int nFlags;
+    script_verify_flags m_flags;
     bool cacheStore;
     PrecomputedTransactionData *txdata;
     SignatureCache* m_signature_cache;
 
 public:
-    CScriptCheck(const CTxOut& outIn, const CTransaction& txToIn, SignatureCache& signature_cache, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn, PrecomputedTransactionData* txdataIn) :
-        m_tx_out(outIn), ptxTo(&txToIn), nIn(nInIn), nFlags(nFlagsIn), cacheStore(cacheIn), txdata(txdataIn), m_signature_cache(&signature_cache) { }
+    CScriptCheck(const CTxOut& outIn, const CTransaction& txToIn, SignatureCache& signature_cache, unsigned int nInIn, script_verify_flags flags, bool cacheIn, PrecomputedTransactionData* txdataIn) :
+        m_tx_out(outIn), ptxTo(&txToIn), nIn(nInIn), m_flags(flags), cacheStore(cacheIn), txdata(txdataIn), m_signature_cache(&signature_cache) { }
 
     CScriptCheck(const CScriptCheck&) = delete;
     CScriptCheck& operator=(const CScriptCheck&) = delete;
@@ -1351,6 +1352,6 @@ bool IsBIP30Repeat(const CBlockIndex& block_index);
 bool IsBIP30Unspendable(const CBlockIndex& block_index);
 
 // Returns the script flags which should be checked for a given block
-unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman);
+script_verify_flags GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman);
 
 #endif // BITCOIN_VALIDATION_H

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -16,6 +16,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "node/blockstorage -> validation -> node/blockstorage",
     "node/utxo_snapshot -> validation -> node/utxo_snapshot",
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel",
+    "qt/freespacechecker -> qt/intro -> qt/freespacechecker",
     "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel",
     "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog",
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel",

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -16,7 +16,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "node/blockstorage -> validation -> node/blockstorage",
     "node/utxo_snapshot -> validation -> node/utxo_snapshot",
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel",
-    "qt/freespacechecker -> qt/intro -> qt/freespacechecker",
     "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel",
     "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog",
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel",


### PR DESCRIPTION
Backport of bitcoin/bitcoin#32998 excluding simplifying `script_verify_flag_name` to an ordinary enum. Includes backport of bitcoin-core/gui#881 due to qt6 bug.