### PR TITLE
Build system fixes

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -368,7 +368,7 @@ mkdir -p "$DISTSRC"
             ;;
         *darwin*)
             cmake --build build --target deploy ${V:+--verbose}
-            mv build/dist/Bitcoin-Core.zip "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.zip"
+            mv build/dist/Bitcoin-Inquisition.zip "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.zip"
             mkdir -p "unsigned-app-${HOST}"
             cp  --target-directory="unsigned-app-${HOST}" \
                 contrib/macdeploy/detached-sig-create.sh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -338,7 +338,6 @@ target_link_libraries(bitcoin_node
 )
 add_dependencies(bitcoin_node generate_binana_info)
 
-
 # Bitcoin Core bitcoind.
 if(BUILD_DAEMON)
   add_executable(bitcoind

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(bitcoinkernel
   PUBLIC
     Boost::headers
 )
+add_dependencies(bitcoinkernel generate_binana_info)
 
 # libbitcoinkernel requires default symbol visibility, explicitly
 # specify that here so that things still work even when user

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -140,6 +140,7 @@ target_link_libraries(bitcoinqt
     $<$<PLATFORM_ID:Darwin>:-framework\ AppKit>
     $<$<CXX_COMPILER_ID:MSVC>:shlwapi>
 )
+add_dependencies(bitcoinqt generate_binana_info)
 
 if(ENABLE_WALLET)
   target_sources(bitcoinqt

--- a/src/test/fuzz/util/CMakeLists.txt
+++ b/src/test/fuzz/util/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(test_fuzz STATIC EXCLUDE_FROM_ALL
   ../fuzz.cpp
   ../util.cpp
 )
+add_dependencies(test_fuzz generate_binana_info)
 
 target_link_libraries(test_fuzz
   PRIVATE

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(test_util STATIC EXCLUDE_FROM_ALL
   validation.cpp
   $<$<BOOL:${ENABLE_WALLET}>:${PROJECT_SOURCE_DIR}/src/wallet/test/util.cpp>
 )
+add_dependencies(test_util generate_binana_info)
 
 target_link_libraries(test_util
   PRIVATE

--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(bitcoin_wallet
     Boost::headers
     $<TARGET_NAME_IF_EXISTS:USDT::headers>
 )
+add_dependencies(bitcoin_wallet generate_binana_info)
 
 if(NOT USE_SQLITE AND NOT USE_BDB)
   message(FATAL_ERROR "Wallet functionality requested but no BDB or SQLite support available.")

--- a/src/zmq/CMakeLists.txt
+++ b/src/zmq/CMakeLists.txt
@@ -19,3 +19,4 @@ target_link_libraries(bitcoin_zmq
     univalue
     zeromq
 )
+add_dependencies(bitcoin_zmq generate_binana_info)


### PR DESCRIPTION
binana.h needs to be marked as a dependency for more things, and the MacOS zip for guix builds is renamed.