### PR TITLE
Disable testnet4 on Inquisition

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1344,7 +1344,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const CChainParams& chainparams = Params();
 
     // Disallow mainnet/testnet operation
-    if (Params().GetChainType() == ChainType::MAIN || Params().GetChainType() == ChainType::TESTNET) {
+    if (Params().GetChainType() != ChainType::REGTEST && Params().GetChainType() != ChainType::SIGNET) {
         return InitError(Untranslated(strprintf("Selected network '%s' is unsupported for this client, select -regtest or -signet instead.\n", Params().GetChainTypeString())));
     }
 


### PR DESCRIPTION
Running on mainnet and testnet3 was disabled, but testnet4 was not.

Specifically check for `-regtest` or `-signet` and deny anything else.